### PR TITLE
Fix for PyTest6 API: use from_parent rather than constructor

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,6 +84,7 @@ intersphinx_aliases = {
 
 nitpick_ignore = [
     ("py:class", "NoneType"),
+    ("py:class", "TypeIO"),
     ("py:class", "attr.ib"),
     ("py:class", "attr.s"),
     ("py:class", "ruamel.yaml.dumper.RoundTripDumper"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,12 +84,13 @@ intersphinx_aliases = {
 
 nitpick_ignore = [
     ("py:class", "NoneType"),
-    ("py:class", "TypeIO"),
+    ("py:class", "TextIO"),
     ("py:class", "attr.ib"),
     ("py:class", "attr.s"),
     ("py:class", "ruamel.yaml.dumper.RoundTripDumper"),
     ("py:exc", "nbconvert.preprocessors.CellExecutionError"),
     ("py:class", "nbdime.diff_format.DiffEntry"),
+    ("py:class", "_pytest.nodes.Item"),
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/pytest_notebook/execution.py
+++ b/pytest_notebook/execution.py
@@ -153,7 +153,7 @@ class ExecuteCoveragePreprocessor(ExecutePreprocessor):
         with self.setup_preprocessor(nb, resources, km=km):
             self.log.info(f"Executing notebook with kernel: {self.kernel_name}")
             if self.coverage and self.kernel_name.startswith("python"):
-                self.log.info(f"Recording coverage for notebook")
+                self.log.info("Recording coverage for notebook")
                 self.coverage_setup(nb_version)
             try:
                 nb, resources = super(ExecutePreprocessor, self).preprocess(

--- a/pytest_notebook/nb_regression.py
+++ b/pytest_notebook/nb_regression.py
@@ -300,7 +300,7 @@ class NBRegressionFixture:
 
         # TODO merge on fail option (using pytest-cov --no-cov-on-fail)
         if self.cov_merge and exec_results.has_coverage:
-            logger.info(f"Merging coverage.")
+            logger.info("Merging coverage.")
             self.cov_merge.data.update(
                 exec_results.coverage_data(self.cov_merge.debug),
                 aliases=_get_coverage_aliases(self.cov_merge),

--- a/pytest_notebook/notebook.py
+++ b/pytest_notebook/notebook.py
@@ -281,7 +281,7 @@ def create_notebook(as_version: int = DEFAULT_NB_VERSION):
     elif as_version == 3:
         notebook = nbformat.v3.new_notebook()
     elif as_version == 4:
-        notebook = nbformat.v4.new_notebook()
+        notebook = nbformat.v4.new_notebook(nbformat_minor=2)
     else:
         raise NotImplementedError(f"notebook version: {as_version}")
     return notebook

--- a/pytest_notebook/plugin.py
+++ b/pytest_notebook/plugin.py
@@ -266,7 +266,7 @@ class JupyterNbCollector(pytest.File):
     def collect(self):
         """Collect tests for the notebook."""
         name = os.path.splitext(os.path.basename(self.fspath))[0]
-        yield JupyterNbTest(f"nbregression({name})", self)
+        yield JupyterNbTest.from_parent(self, name=f"nbregression({name})")
 
 
 class JupyterNbTest(pytest.Item):

--- a/pytest_notebook/plugin.py
+++ b/pytest_notebook/plugin.py
@@ -254,7 +254,7 @@ def pytest_collect_file(path, parent):
     if other_args.get("nb_test_files", False) and any(
         path.fnmatch(pat) for pat in other_args.get("nb_file_fnmatch", ["*.ipynb"])
     ):
-        return JupyterNbCollector(path, parent)
+        return JupyterNbCollector.from_parent(parent, fspath=path)
 
 
 class JupyterNbCollector(pytest.File):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     extras_require={
         "testing": [
-            "coverage",
+            "coverage~=4.5.1",
             "pytest-cov",
             "pytest-regressions",
             "black==19.3b0",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "pytest>=3.5.0",
         "attrs",
         "jupyter_client",
-        "nbconvert",
+        "nbconvert~=5.6.0",
         "nbdime",
         "nbformat",
         "jsonschema",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytest>=3.5.0",
-        "attrs",
+        "attrs<21,>=19",
         "jupyter_client",
         "nbconvert~=5.6.0",
         "nbdime",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             "ipypublish>=0.10.7",
             "ruamel.yaml",
             "ruamel.yaml.clib",
-            "coverage",
+            "coverage~=4.5.1",
         ],
     },
     classifiers=[


### PR DESCRIPTION
Fixes #9 following [PyTest docs](https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent)