### PR TITLE
📚 DOCS: Add usage description for pytest CLI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ To install the development version:
 
 See the documentation at: http://pytest-notebook.readthedocs.io/
 
+If you want to test some sample notebooks, add the `--nb-test-files` flag:
+
+```shell
+>> git clone https://github.com/chrisjsewell/pytest-notebook
+>> cd pytest-notebook/samples
+>> pip install pytest ipykernel pytest-notebook
+>> pytest --nb-test-files *.ipynb
+```
+
+You should see `success.ipynb` passed the test and `fail.ipynb` failed the test.
+
+You can regenerate the outputs of `fail.ipynb` with the `--nb-force-regen` flag:
+
+```shell
+>> pytest --nb-test-files --nb-force-regen *.ipynb
+```
+
 ## Contributing
 
 Contributions are very welcome.

--- a/examples/fail.ipynb
+++ b/examples/fail.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "B\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"A\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/success.ipynb
+++ b/examples/success.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"A\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
New users may want to quickly find the pytest CLI usage of `--nb-test-files` to test their notebooks. But they will need to go through half the [pytest-notebook by example](https://pytest-notebook.readthedocs.io/en/latest/user_guide/tutorial_intro.html#pytest-file-collection) page to find this flag, or use `pytest --help` to find it.

I think it'll be nice to provide a short description of this flag in the README file.