### PR TITLE
Coverage.py fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[testing]
     - name: Run pytest
-      run: pytest --durations=10 --cov=pytest_notebook --cov-report=xml --cov-report=term-missing
+      run: pytest --durations=10 --cov=pytest_notebook --cov-report=xml --cov-report=term-missing --nb-coverage
 
     - name: Create cov
       run: coverage xml

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you want to test some sample notebooks, add the `--nb-test-files` flag:
 
 ```shell
 >> git clone https://github.com/chrisjsewell/pytest-notebook
->> cd pytest-notebook/samples
+>> cd pytest-notebook/examples
 >> pip install pytest ipykernel pytest-notebook
 >> pytest --nb-test-files *.ipynb
 ```

--- a/pytest_notebook/nb_regression.py
+++ b/pytest_notebook/nb_regression.py
@@ -301,14 +301,14 @@ class NBRegressionFixture:
         # TODO merge on fail option (using pytest-cov --no-cov-on-fail)
         if self.cov_merge and exec_results.has_coverage:
             logger.info("Merging coverage.")
-            self.cov_merge.data.update(
-                exec_results.coverage_data(self.cov_merge.debug),
+            self.cov_merge.get_data().update(
+                exec_results.coverage_data(debug=self.cov_merge._debug),
                 aliases=_get_coverage_aliases(self.cov_merge),
             )
             # we also take this opportunity to remove ''
             # from the unmatched source packages, which is caused by using `--cov=`
-            self.cov_merge.source_pkgs_unmatched = [
-                p for p in self.cov_merge.source_pkgs_unmatched if p
+            self.cov_merge._inorout.source_pkgs_unmatched = [
+                p for p in self.cov_merge._inorout.source_pkgs_unmatched if p
             ]
 
         for proc_name in self.post_processors:


### PR DESCRIPTION
Merging the coverage data failed for me due to misnamed members in the `Coverage` instance. I've changed them to what I gathered was actually intended. This works for me now with both `coverage==5.5` (as pinned in this project) and with `coverage==6.4.1` (the current version). 

Would it make sense to run the tests with `--nb-coverage`?