### PR TITLE
Dependencies: Add support for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - uses: pre-commit/action@v2.0.0
 
   tests:
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 

--- a/docs/source/user_guide/tutorial_coverage.md
+++ b/docs/source/user_guide/tutorial_coverage.md
@@ -94,12 +94,16 @@ and merge the data back into the main {py:class}`~coverage.Coverage` object.
 %%pytest --disable-warnings --color=yes --cov=pytest_notebook --nb-coverage --log-cli-level=info
 
 import logging
-from importlib import resources as importlib_resources
+try:
+    # Python <= 3.8
+    from importlib_resources import files
+except ImportError:
+    from importlib.resources import files
 from pytest_notebook import example_nbs
 
 def test_notebook(nb_regression):
     logging.getLogger(__name__).info(nb_regression)
-    with importlib_resources.path(example_nbs, "coverage.ipynb") as path:
+    with files(example_nbs).joinpath("coverage.ipynb") as path:
         nb_regression.check(str(path))
 ```
 

--- a/docs/source/user_guide/tutorial_intro.md
+++ b/docs/source/user_guide/tutorial_intro.md
@@ -28,7 +28,11 @@ The principal component of `pytest-notebook` is the
 which is an [attrs](http://www.attrs.org) class, whose parameters can be instantiated or set via attributes.
 
 ```{code-cell} ipython3
-from importlib import resources as importlib_resources
+try:
+    # Python <= 3.8
+    from importlib_resources import files
+except ImportError:
+    from importlib.resources import files
 from pytest_notebook import example_nbs
 from pytest_notebook.nb_regression import NBRegressionFixture
 ```
@@ -44,14 +48,14 @@ The main method is {py:meth}`~pytest_notebook.nb_regression.NBRegressionFixture.
 ```{code-cell} ipython3
 :tags: [raises-exception]
 
-with importlib_resources.path(example_nbs, "example1.ipynb") as path:
+with files(example_nbs).joinpath("example1.ipynb") as path:
     fixture.check(str(path))
 ```
 
 To return the results, without raising an exception, use ``raise_errors=False``. This returns a {py:class}`~pytest_notebook.nb_regression.NBRegressionResult` instance.
 
 ```{code-cell} ipython3
-with importlib_resources.path(example_nbs, "example1.ipynb") as path:
+with files(example_nbs).joinpath("example1.ipynb") as path:
     result = fixture.check(str(path), raise_errors=False)
 
 result
@@ -103,12 +107,15 @@ The command-line parameter takes precedence over the configuration file one.
 [pytest]
 nb_diff_color_words = True
 ---
-
-import importlib_resources
+try:
+    # Python <= 3.8
+    from importlib_resources import files
+except ImportError:
+    from importlib.resources import files
 from pytest_notebook import example_nbs
 
 def test_notebook(nb_regression):
-    with importlib_resources.path(example_nbs, "example1.ipynb") as path:
+    with files(example_nbs).joinpath("example1.ipynb") as path:
         nb_regression.check(str(path))
 ```
 
@@ -120,8 +127,8 @@ def test_notebook(nb_regression):
 To activate this feature, set `--nb-test-files` on the command-line, or `nb_test_files = True` in the configuration file.
 
 ```{code-cell} ipython3
-notebook1_content = importlib_resources.read_text(example_nbs, "example1_pass.ipynb")
-notebook2_content = importlib_resources.read_text(example_nbs, "example1.ipynb")
+notebook1_content = files(example_nbs).joinpath("example1_pass.ipynb").read_text()
+notebook2_content = files(example_nbs).joinpath("example1.ipynb").read_text()
 ```
 
 ```{code-cell} ipython3
@@ -224,7 +231,7 @@ def notebook():
     tmphandle, tmppath = tempfile.mkstemp(suffix=".ipynb")
     with open(tmppath, "w") as handle:
         handle.write(
-            importlib_resources.read_text(example_nbs, "example1.ipynb")
+            files(example_nbs).joinpath("example1.ipynb").read_text()
         )
     yield tmppath
     os.remove(tmppath)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Operating System :: OS Independent",
   "License :: OSI Approved :: BSD License",
@@ -26,6 +28,7 @@ requires-python = "~=3.7"
 dependencies = [
   "pytest>=3.5.0",
   "attrs<23,>=19",
+  "importlib-resources~=5.0;python_version<'3.9'",
   "nbclient~=0.5.10",
   "nbdime",
   "nbformat",

--- a/pytest_notebook/notebook.py
+++ b/pytest_notebook/notebook.py
@@ -1,7 +1,13 @@
 """Module for working with notebook."""
 import copy
 from functools import lru_cache
-from importlib import resources as importlib_resources
+
+try:
+    # Python <= 3.8
+    from importlib_resources import files
+except ImportError:
+    from importlib.resources import files
+
 import json
 import re
 from typing import Any, Callable, Mapping, TextIO, Tuple, Union
@@ -142,7 +148,7 @@ def validate_regex_replace(args, index):
 @lru_cache()
 def _load_validator():
     schema = json.loads(
-        importlib_resources.read_text(resources, "nb_metadata.schema.json")
+        files(resources).joinpath("nb_metadata.schema.json").read_text(encoding="utf-8")
     )
     validator_cls = jsonschema.validators.validator_for(schema)
     return validator_cls(schema=schema)


### PR DESCRIPTION
In Python 3.11, the `read_text` and `path` methods of the `importlib.resources` package of the standard library are deprecated. They should now be accessed through the `files` interface. This has only been added since Python 3.9 though, so for older versions we require the `importlib_resources` backport package to be installed.