### PR TITLE
Restrict nbdime dependency to <4 to workaround #59

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "importlib-metadata~=6.0;python_version<'3.10'",
   "importlib-resources~=5.0;python_version<'3.9'",
   "nbclient~=0.5.10",
-  "nbdime",
+  "nbdime<4",
   "nbformat",
   "jsonschema",
 ]


### PR DESCRIPTION
Workaround for #59