### PR TITLE
⬆️ Support nbdime v4 (drop <4 support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,12 +104,18 @@ ENV/
 env.bak/
 venv.bak/
 
+# PyCharm project settings
+.idea
+
 # Spyder project settings
 .spyderproject
 .spyproject
 
 # Rope project settings
 .ropeproject
+
+# VSCode project settings
+.vscode
 
 # mkdocs documentation
 /site
@@ -125,4 +131,3 @@ dmypy.json
 .DS_Store
 _archive/
 docs/source/apidoc/
-.vscode/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,7 @@ intersphinx_mapping = {
     "_pytest": ("https://doc.pytest.org/en/latest/", None),
     # "PIL": ("http://pillow.readthedocs.org/en/latest/", None),
     "nbclient": ("https://nbclient.readthedocs.io/en/latest/", None),
+    "nbdime": ("https://nbdime.readthedocs.io/en/latest/", None),
     "nbformat": ("https://nbformat.readthedocs.io/en/latest/", None),
     "attr": ("https://www.attrs.org/en/stable/", None),
     "coverage": ("https://coverage.readthedocs.io/en/6.2/", None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,7 @@ nitpick_ignore = [
     ("py:class", "Session"),
     ("py:exc", "nbconvert.preprocessors.CellExecutionError"),
     ("py:class", "nbdime.diff_format.DiffEntry"),
+    ("py:class", "nbdime.diffing.config.DiffConfig"),
     ("py:class", "_pytest._py.path.LocalPath"),
     ("py:meth", "Item.reportinfo"),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "importlib-metadata~=6.0;python_version<'3.10'",
   "importlib-resources~=5.0;python_version<'3.9'",
   "nbclient~=0.5.10",
-  "nbdime",
+  "nbdime>=4",
   "nbformat",
   "jsonschema",
 ]


### PR DESCRIPTION
## About

- This patch addresses the incompatibility with nbdime version 4, as reported by @renonat at GH-59.
- @krassowski provided a guide how to tweak the code correspondingly at https://github.com/chrisjsewell/pytest-notebook/issues/59#issuecomment-1828330758, which was easy to follow -- thanks a stack!
- The fix may supersede GH-60 submitted by @cpascual -- also thanks for jumping on this so quickly.
