### PR TITLE
Fix update to pytest 8.0.0 [UNFINISHED]

### DIFF
--- a/pytest_notebook/plugin.py
+++ b/pytest_notebook/plugin.py
@@ -12,6 +12,7 @@ For more information on writing pytest plugins see:
 """
 import os
 import shlex
+from pathlib import Path
 
 import pytest
 
@@ -270,7 +271,7 @@ def pytest_collect_file(path, parent):
         path.fnmatch(pat) for pat in other_args.get("nb_file_fnmatch", ["*.ipynb"])
     ):
         try:
-            return JupyterNbCollector.from_parent(parent, fspath=path)
+            return JupyterNbCollector.from_parent(parent, path=Path(path))
         except AttributeError:
             return JupyterNbCollector(path, parent)
 


### PR DESCRIPTION
## About
This patch partly fixes updating to pytest 8.0.0, two of [four test case failures](https://github.com/chrisjsewell/pytest-notebook/issues/73#issuecomment-1915627317) succeed now.

## Backlog
Unfortunately, I [can't make any sense of the error output](https://github.com/chrisjsewell/pytest-notebook/issues/73#issuecomment-1915631542) from the two other tests still failing. Can you have a look if you can afford the time, @chrisjsewell?
