### PR TITLE
deps: loosen `nbclient` dependency version bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "attrs<23,>=19",
   "importlib-metadata~=6.0;python_version<'3.10'",
   "importlib-resources~=5.0;python_version<'3.9'",
-  "nbclient~=0.5.10",
+  "nbclient~=0.5,>=0.5.10",
   "nbdime>=4",
   "nbformat",
   "jsonschema",


### PR DESCRIPTION
The current bounds, `~=0.5.10`, translate to `>= 0.5.10, == 0.5.*` according to the "Version specifiers" spec. Given `nbclient` is currently at version 0.10.0, loosening the bounds allows for `pytest-notebook` to be used in environments using newer versions of `nbclient`.

See: https://packaging.python.org/en/latest/specifications/version-specifiers/#compatible-release