### PR TITLE
‼️ Modernize: Python 3.10+, pytest 8/9 support, dependency groups, repo infrastructure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,10 @@ updates:
     commit-message:
       prefix: ⬆️
     schedule:
-      interval: monthly
+      interval: weekly
   - package-ecosystem: pip
     directory: /
     commit-message:
       prefix: ⬆️
     schedule:
-      interval: monthly
+      interval: weekly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,13 @@ on:
       - 'v*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
 
   pre-commit:
@@ -15,11 +22,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
-    - uses: pre-commit/action@v3.0.0
+        python-version: '3.11'
+    - uses: pre-commit/action@v3.0.1
 
   tests:
 
@@ -27,20 +34,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+        cache: pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[testing]
+        pip install --group test -e .
     - name: Run pytest
       run: pytest --durations=10 --cov=pytest_notebook --cov-report=xml --cov-report=term-missing --nb-coverage
 
@@ -48,8 +57,8 @@ jobs:
       run: coverage xml
 
     - name: Upload to Codecov
-      if: github.repository == 'chrisjsewell/pytest-notebook'
-      uses: codecov/codecov-action@v3
+      if: github.repository == 'chrisjsewell/pytest-notebook' && matrix.python-version == '3.11'
+      uses: codecov/codecov-action@v5
       with:
         name: pytests-notebook
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -79,22 +88,23 @@ jobs:
   publish:
 
     name: Publish to PyPi
-    needs: [pre-commit, tests]
+    needs: [all-good]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pytest-notebook
+    permissions:
+      id-token: write
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
-    - name: install flit
+        python-version: '3.11'
+    - name: Build package
       run: |
-        pip install flit~=3.4
-    - name: Build and publish
-      run: |
-        flit publish
-      env:
-        FLIT_USERNAME: __token__
-        FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}
+        pipx run flit build
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
     - id: check-json
     - id: check-yaml
@@ -14,8 +14,8 @@ repos:
       exclude: ^tests/.*\.txt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.15.12
     hooks:
-    - id: ruff
+    - id: ruff-check
       args: [--fix]
     - id: ruff-format

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,5 +13,6 @@ python:
           - docs
 
 sphinx:
+  configuration: docs/source/conf.py
   builder: html
   fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.12"
 
 python:
   install:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,245 @@
+# AGENTS.md
+
+This file provides guidance for AI coding agents working on the **pytest-notebook** repository.
+
+## Project Overview
+
+pytest-notebook is a [pytest](https://docs.pytest.org) plugin for regression-testing and executing [Jupyter Notebooks](https://jupyter.org/). It provides:
+
+- Collection of `.ipynb` files as pytest tests (each notebook becomes a test item)
+- Execution of notebooks via [nbclient](https://nbclient.readthedocs.io), with optional [coverage.py](https://coverage.readthedocs.io) integration
+- Regression testing of notebook outputs by diffing against the stored notebook, using [nbdime](https://nbdime.readthedocs.io)
+- Configurable diff ignoring, regex replacement, and output post-processing
+- An `nb_regression` fixture and a `%%pytest` IPython magic for interactive use
+
+pytest-notebook is designed to make notebooks a first-class, testable artifact, verifying that they execute cleanly and that their outputs remain stable.
+
+Documentation is hosted at [pytest-notebook.readthedocs.io](https://pytest-notebook.readthedocs.io).
+
+## Repository Structure
+
+```
+pyproject.toml          # Project configuration and dependencies (flit)
+tox.ini                 # Tox environments + [pytest] self-testing config
+
+pytest_notebook/        # Main source code
+├── __init__.py         # Package init / version
+├── plugin.py           # pytest hooks, `nb_regression` fixture, notebook collector
+├── nb_regression.py    # NBRegressionFixture - core execute + diff logic
+├── execution.py        # nbclient-based execution, coverage.py integration
+├── diffing.py          # nbdime diffing, filtering, and formatting of diffs
+├── notebook.py         # Notebook loading + `nbreg` metadata config (JSON-schema validated)
+├── post_processors.py  # Entry-point post-processors (coalesce_streams, blacken_code, beautifulsoup)
+├── ipy_magic.py        # `%pytest` / `%%pytest` IPython magic
+├── utils.py            # Utility helpers (e.g. autodoc)
+├── resources/          # JSON schema and other package resources
+└── example_nbs/        # Example notebooks
+
+tests/                  # Test suite
+├── conftest.py         # Shared fixtures
+├── test_nb_regression.py   # NBRegressionFixture tests
+├── test_execution.py       # Execution tests
+├── test_nb_diff.py         # Notebook diffing tests
+├── test_cell_diff.py       # Cell-level diffing tests
+├── test_filter_diff.py     # Diff filtering tests
+├── test_notebook.py        # Notebook loading / config tests
+├── test_coalesce_streams.py, test_postprocessors/  # Post-processor tests
+├── test_plugin_collector.py, test_plugin_fixture.py # Plugin/collector/fixture tests
+├── test_ipy_magic.py       # IPython magic tests
+├── test_utils.py
+└── raw_files/          # Stored fixtures for pytest-regressions comparisons
+
+docs/                   # Documentation source (Sphinx + myst-nb)
+└── source/
+    ├── conf.py         # Sphinx configuration
+    ├── index.rst       # Documentation index
+    ├── changelog.md    # Changelog (update on every user-facing change)
+    ├── user_guide/     # User guide notebooks/pages
+    ├── apidoc/         # API documentation
+    └── literal_includes/
+```
+
+## Development Commands
+
+Tests can be run either via [`tox`](https://tox.wiki) (recommended, for isolated environments) or directly with pytest in a local install.
+
+### Testing
+
+```bash
+# Run the default environment
+tox
+
+# Run tests with a specific Python version
+tox -e py311 -- {pytest args}
+
+# Run a specific test file
+tox -e py311 -- tests/test_nb_regression.py
+
+# Run a specific test function
+tox -e py311 -- tests/test_nb_regression.py::test_basic_execution
+```
+
+Or, for a local (non-tox) workflow, install the test dependency group and run pytest directly:
+
+```bash
+# Install the package with the PEP 735 `test` dependency group
+pip install --group test -e .
+
+# Run the tests
+pytest
+```
+
+> Test dependencies live in the PEP 735 `[dependency-groups]` `test` group in `pyproject.toml`
+> (this replaces the old `testing` extra). Documentation dependencies are the `docs` extra.
+
+### Documentation
+
+```bash
+# Build docs (clean rebuild)
+tox -e docs-clean
+
+# Build docs (incremental update)
+tox -e docs-update
+```
+
+The docs environment runs `make` in the `docs/` directory using the `docs` extra.
+
+### Code Quality
+
+```bash
+# Run pre-commit hooks on all files (ruff + ruff-format)
+pre-commit run --all-files
+
+# Linting and formatting individually
+pre-commit run ruff --all-files
+pre-commit run ruff-format --all-files
+```
+
+There is no mypy / type-checking step configured in this repository.
+
+## Code Style Guidelines
+
+- **Formatter/Linter**: Ruff (configured in `pyproject.toml`, `[tool.ruff.lint]`)
+- **Pre-commit**: Use pre-commit hooks for consistent code style (`.pre-commit-config.yaml`)
+- **Python**: Requires Python `>=3.10`
+
+### Best Practices
+
+- **Docstrings**: Use Sphinx-style (`:param:` / `:return:`) docstrings, as used throughout the codebase.
+- **attrs**: Configuration classes (e.g. `NBRegressionFixture`) use [attrs](https://www.attrs.org) with validators; follow the existing pattern when adding options.
+- **Import sorting**: isort is enabled with `force-sort-within-sections` (via Ruff).
+- **Testing**: Write tests for all new functionality. Use `pytest-regressions` for output comparison tests.
+
+## Architecture Overview
+
+The core flow is: **collect a notebook → execute it → diff its new outputs against the stored outputs → report differences**.
+
+### Key Components
+
+#### Plugin (`plugin.py`)
+
+The pytest integration layer:
+
+- `pytest_addoption` / `pytest_report_header` – register and report configuration options
+- `nb_regression` fixture (function scope) – exposes an `NBRegressionFixture` built from pytest config
+- `pytest_collect_file` + `JupyterNbCollector` (a `pytest.File`) and `JupyterNbTest` (a `pytest.Item`) – collect `.ipynb` files as test items when notebook testing is enabled
+
+#### NBRegressionFixture (`nb_regression.py`)
+
+The core class tying everything together: it loads a notebook, executes it, applies post-processors and diff filtering, diffs against the original, and raises/reports on differences (with a `--nb-force-regen`-style regeneration path).
+
+#### Execution (`execution.py`)
+
+Executes notebooks with `nbclient.NotebookClient`, handling timeouts, allowed errors, working directory, and optional coverage.py data collection (injected via setup/teardown code cells).
+
+#### Diffing (`diffing.py`)
+
+Wraps nbdime to compute notebook diffs, filter out ignored paths, and pretty-print/format the resulting diff. (Note: nbdime is currently hard-coded to notebook format v4.)
+
+#### Notebook config (`notebook.py`)
+
+Loads notebooks and reads per-notebook configuration from the `nbreg` notebook metadata key (`META_KEY = "nbreg"`), validated against a JSON schema in `resources/`. Also provides regex-replacement helpers.
+
+#### Post-processors (`post_processors.py`)
+
+Registered via the `nbreg.post_proc` entry-point group. Built-in processors:
+
+- `coalesce_streams` – merge consecutive stream outputs
+- `blacken_code` – format code cells with black
+- `beautifulsoup` – normalize HTML outputs
+
+#### IPython magic (`ipy_magic.py`)
+
+Provides the `%pytest` line and `%%pytest` cell magics (loaded via `%load_ext pytest_notebook.ipy_magic`) to run pytest against inline test content from within a notebook.
+
+## Testing Guidelines
+
+- Tests use `pytest` with fixtures from `tests/conftest.py`.
+- Regression testing uses `pytest-regressions` (`file_regression` / `data_regression`); stored fixtures live under `tests/raw_files/` (and per-test folders such as `tests/test_nb_diff/`).
+- pytest-notebook self-tests some of its own documentation notebooks: the `[pytest]` section in `tox.ini` configures `nb_file_fnmatch` (which notebooks to collect) and `nb_diff_replace` (regex substitutions to normalize volatile output such as paths, timings, and platform/plugin banners).
+
+> **Caution:** Because outputs are compared exactly, changing the installed **black** or **IPython** version (or other output-affecting dependencies) can shift regression fixtures. Regenerate fixtures deliberately and review the diffs when this happens.
+
+### Test Best Practices
+
+- **Test coverage**: Write tests for all new functionality and bug fixes.
+- **Isolation**: Each test should be independent.
+- **Descriptive names**: Test function names should describe what is being tested.
+- **Regression testing**: Use the `file_regression.check()` fixture for complex output comparisons.
+
+## Commit Message Format
+
+Use this format:
+
+```
+<EMOJI> <KEYWORD>: Summarize in 72 chars or less (#<PR>)
+
+Optional detailed explanation.
+```
+
+Keywords:
+
+- `✨ NEW:` – New feature
+- `🐛 FIX:` – Bug fix
+- `👌 IMPROVE:` – Improvement (no breaking changes)
+- `‼️ BREAKING:` – Breaking change
+- `📚 DOCS:` – Documentation
+- `🔧 MAINTAIN:` – Maintenance changes only (typos, etc.)
+- `🧪 TEST:` – Tests or CI changes only
+- `♻️ REFACTOR:` – Refactoring
+
+## PR Title and Description Format
+
+Use the same format as commit messages, but for the title you can omit the `KEYWORD` and only use `EMOJI`.
+
+## Pull Request Requirements
+
+When submitting changes:
+
+1. **Description**: Include a meaningful description or link explaining the change.
+2. **Tests**: Include test cases for new functionality or bug fixes.
+3. **Documentation**: Update the docs if behavior changes or new features are added.
+4. **Changelog**: Update `docs/source/changelog.md` under the appropriate section.
+5. **Code Quality**: Ensure `pre-commit run --all-files` passes.
+
+## Key Files
+
+- `pyproject.toml` – Project configuration, dependencies, dependency groups, entry points, and Ruff settings
+- `tox.ini` – Tox environments and the `[pytest]` self-testing configuration
+- `pytest_notebook/plugin.py` – pytest hooks, `nb_regression` fixture, notebook collector
+- `pytest_notebook/nb_regression.py` – `NBRegressionFixture` core execute + diff logic
+- `pytest_notebook/execution.py` – nbclient execution and coverage.py integration
+- `pytest_notebook/diffing.py` – nbdime diffing, filtering, and formatting
+- `pytest_notebook/notebook.py` – notebook loading and `nbreg` metadata config
+- `pytest_notebook/post_processors.py` – entry-point post-processors
+- `pytest_notebook/ipy_magic.py` – `%pytest` / `%%pytest` IPython magic
+- `docs/source/changelog.md` – Changelog
+
+## Reference Documentation
+
+- [pytest-notebook Documentation](https://pytest-notebook.readthedocs.io)
+- [pytest-notebook Repository](https://github.com/chrisjsewell/pytest-notebook)
+- [pytest Documentation](https://docs.pytest.org)
+- [nbclient Documentation](https://nbclient.readthedocs.io)
+- [nbdime Documentation](https://nbdime.readthedocs.io)
+- [nbformat Documentation](https://nbformat.readthedocs.io)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ git clone https://github.com/chrisjsewell/pytest-notebook .
 cd pytest-notebook
 pip install --upgrade pip
 pip install -e .
-# pip install -e .[code_style,testing,docs] # install extras for more features
+# pip install --group test --group pre_commit -e .[docs] # install development dependencies
 ```
 
 ## Usage
@@ -96,31 +96,24 @@ Contributions are very welcome.
 The following will discover and run all unit test:
 
 ```shell
-pip install -e .[testing]
+pip install --group test -e .
 pytest -v
 ```
 
 ### Coding Style Requirements
 
-The code style is tested using [flake8](http://flake8.pycqa.org),
-with the configuration set in `.flake8`,
-and code should be formatted with [black](https://github.com/ambv/black).
+The code style is tested and formatted using [ruff](https://docs.astral.sh/ruff/),
+with the configuration set in `pyproject.toml`.
 
-Installing with `pytest-notebook[code_style]` makes the [pre-commit](https://pre-commit.com/)
-package available, which will ensure these tests are passed by reformatting the code
+Installing the `pre_commit` dependency group (`pip install --group pre_commit -e .`)
+makes the [pre-commit](https://pre-commit.com/) package available, which will
+ensure the code style is met by reformatting the code
 and testing for lint errors before submitting a commit.
 It can be setup by:
 
 ```shell
 cd pytest-notebook
 pre-commit install
-```
-
-Optionally you can run `black` and `flake8` separately:
-
-```shell
-black .
-flake8 .
 ```
 
 Editors like VS Code also have automatic code reformat utilities, which can adhere to this standard.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.11.0 (2026-07-12)
+
+‼️ **BREAKING**: Python 3.10+ and pytest 7.4+ are now required.
+
+* ‼️ Drop Python 3.8/3.9 support; add official Python 3.13 support
+* 🐛 Fix compatibility with pytest 8/9: port the notebook collector from the removed `py.path`/`fspath` API to the `pathlib` based API ([#73](https://github.com/chrisjsewell/pytest-notebook/issues/73), [#81](https://github.com/chrisjsewell/pytest-notebook/issues/81))
+* ⬆️ Un-pin `attrs` (now `>=21`), `nbclient` (now `>=0.5.10`, tested against 0.11) and `coverage` (now v6.5+, tested against v7) ([#84](https://github.com/chrisjsewell/pytest-notebook/issues/84))
+* ✨ Notebooks can now skip themselves at runtime, by raising `pytest.skip(...)` within a cell ([#43](https://github.com/chrisjsewell/pytest-notebook/issues/43))
+* ✨ Add `exec_env` fixture option / `nb_exec_env` ini option (lines of `KEY=VALUE`), to set environment variables for the kernel, e.g. `PYTHONPATH` ([#15](https://github.com/chrisjsewell/pytest-notebook/issues/15), [#85](https://github.com/chrisjsewell/pytest-notebook/issues/85))
+* 🔧 Move development dependencies from `testing`/`code_style` extras to PEP 735 dependency groups (`test`, `pre_commit`); the `docs` extra is retained
+* 🔧 Add `AGENTS.md`, update pre-commit hooks (ruff v0.15) and CI (Python 3.10-3.13 matrix, PyPI trusted publishing, weekly dependabot)
+
 ## v0.10.0 (2023-11-28)
 
 * ⬆️ Support nbdime v4 (drop v3 support) by @amotl and @krassowski in <https://github.com/chrisjsewell/pytest-notebook/pull/62>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ release = pytest_notebook.__version__
 version = ".".join(release.split(".")[:2])
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8", None),
+    "python": ("https://docs.python.org/3.12", None),
     "_pytest": ("https://doc.pytest.org/en/latest/", None),
     # "PIL": ("http://pillow.readthedocs.org/en/latest/", None),
     "nbclient": ("https://nbclient.readthedocs.io/en/latest/", None),

--- a/docs/source/user_guide/get_started.md
+++ b/docs/source/user_guide/get_started.md
@@ -20,7 +20,7 @@ To install the development version:
 ```shell
 >> git clone https://github.com/chrisjsewell/pytest-notebook .
 >> cd pytest-notebook
->> pip install -e ".[code_style,testing,docs]"
+>> pip install --group test --group pre_commit -e ".[docs]"
 ```
 
 # Development
@@ -38,13 +38,12 @@ It is recommended to use [tox](https://tox.readthedocs.io) to run tests.
 
 ## Coding Style Requirements
 
-[![Code style: black][black-badge]][black-link]
+The code style is tested and formatted using
+[ruff](https://docs.astral.sh/ruff/),
+with the configuration set in `pyproject.toml`.
 
-The code style is tested using [flake8](http://flake8.pycqa.org),
-with the configuration set in `.flake8`, and
-[black](https://github.com/ambv/black).
-
-Installing with `pytest-notebook[code_style]` makes the
+Installing the `pre_commit` dependency group
+(`pip install --group pre_commit -e .`) makes the
 [pre-commit](https://pre-commit.com/) package available, which will
 ensure these tests are passed by reformatting the code and testing for
 lint errors before submitting a commit. It can be set up by:
@@ -78,5 +77,3 @@ The documentation can be created locally by:
 [pypi-link]: https://pypi.org/project/pytest-notebook
 [conda-badge]: https://anaconda.org/conda-forge/pytest-notebook/badges/version.svg
 [conda-link]: https://anaconda.org/conda-forge/pytest-notebook
-[black-badge]: https://img.shields.io/badge/code%20style-black-000000.svg
-[black-link]: https://github.com/ambv/black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,22 +15,19 @@ classifiers = [
   "Topic :: Software Development :: Testing",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Operating System :: OS Independent",
   "License :: OSI Approved :: BSD License",
 ]
-requires-python = "~=3.8"
+requires-python = ">=3.10"
 dependencies = [
-  "pytest>=3.5.0",
-  "attrs<23,>=19",
-  "importlib-metadata~=6.0;python_version<'3.10'",
-  "importlib-resources~=5.0;python_version<'3.9'",
-  "nbclient~=0.5.10",
+  "pytest>=7.4",
+  "attrs>=21",
+  "nbclient>=0.5.10",
   "nbdime>=4",
   "nbformat",
   "jsonschema",
@@ -41,27 +38,26 @@ Source = "https://github.com/chrisjsewell/pytest-notebook"
 Documentation = "https://pytest-notebook.readthedocs.io"
 
 [project.optional-dependencies]
-testing = [
-  "pytest-cov",
-  "pytest-regressions",
-  "ipykernel",
-  "coverage~=5.0",
-  "black==23.11.0",
-  "beautifulsoup4==4.12.2",
-]
-code_style = [
-  "pre-commit~=3.5.0",
-  "doc8>=0.8.0,<1.2.0",
-]
 docs = [
-  "sphinx>=3",
+  "sphinx>=5",
   "pyyaml",
-  "sphinx-book-theme~=1.0.1",
+  "sphinx-book-theme~=1.1",
   "myst-nb~=1.0",
-  "coverage~=5.0",
+  "coverage",
   "pytest-cov",
   "black",
 ]
+
+[dependency-groups]
+test = [
+  "pytest-cov",
+  "pytest-regressions",
+  "ipykernel",
+  "coverage>=6.5",
+  "black",
+  "beautifulsoup4~=4.12",
+]
+pre_commit = ["pre-commit"]
 
 [project.entry-points."pytest11"]
 nb_regression = "pytest_notebook.plugin"
@@ -72,6 +68,10 @@ blacken_code = "pytest_notebook.post_processors:blacken_code"
 beautifulsoup = "pytest_notebook.post_processors:beautifulsoup"
 
 [tool.ruff]
+# notebooks contain deliberately unformatted code, used in regression tests
+extend-exclude = ["*.ipynb"]
+
+[tool.ruff.lint]
 extend-select = ["B0", "C4", "I", "ICN", "ISC", "N", "RUF", "SIM", "UP"]
 extend-ignore = ["ISC001"]
 

--- a/pytest_notebook/__init__.py
+++ b/pytest_notebook/__init__.py
@@ -1,2 +1,3 @@
 """A pytest plugin for testing Jupyter Notebooks."""
+
 __version__ = "0.10.0"

--- a/pytest_notebook/__init__.py
+++ b/pytest_notebook/__init__.py
@@ -1,3 +1,3 @@
 """A pytest plugin for testing Jupyter Notebooks."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/pytest_notebook/diffing.py
+++ b/pytest_notebook/diffing.py
@@ -1,8 +1,9 @@
 """Diffing of notebooks."""
+
+from collections.abc import Sequence
 import copy
 import operator
 import re
-from typing import List, Sequence
 
 from nbdime.diff_format import DiffEntry, SequenceDiffBuilder
 from nbdime.diffing.config import DiffConfig
@@ -64,7 +65,7 @@ def diff_sequence_simple(
 
 def diff_notebooks(
     initial: NotebookNode, final: NotebookNode, initial_path: str = ""
-) -> List[DiffEntry]:
+) -> list[DiffEntry]:
     """Compare two notebooks.
 
     This is a simplified version of ``nbdime.diff_notebooks()``, where we replace
@@ -116,8 +117,8 @@ def star_path(path):
 
 
 def filter_diff(
-    diff: List[DiffEntry], remove_paths: List[str], path: str = ""
-) -> List[DiffEntry]:
+    diff: list[DiffEntry], remove_paths: list[str], path: str = ""
+) -> list[DiffEntry]:
     r"""Filter a notebook diff object, removing a list of paths.
 
     Paths are joined by '/' and may be starred, e.g. '/cells/\*/outputs'.

--- a/pytest_notebook/execution.py
+++ b/pytest_notebook/execution.py
@@ -1,4 +1,5 @@
 """Execution of notebooks."""
+
 from contextlib import nullcontext
 import copy
 import json
@@ -6,7 +7,6 @@ import logging
 from pathlib import Path
 import tempfile
 from textwrap import dedent
-from typing import List, Optional, Union
 
 import attr
 from attr.validators import instance_of
@@ -28,11 +28,11 @@ HELP_COVERAGE_SOURCE = "A list of file paths or package names to measure coverag
 COVERAGE_KEY = "coverage_data"
 
 
-def coverage_code_setup(
-    source: Optional[str], config_file: Union[None, str, Path]
-) -> str:
+def coverage_code_setup(source: str | None, config_file: None | str | Path) -> str:
     source = f"{source!r}" if source else "None"
-    config_file = f"{config_file!r}" if config_file else "None"
+    # False disables reading a configuration file
+    # (the pre coverage v6.4 meaning of None)
+    config_file = f"{config_file!r}" if config_file else "False"
     return dedent(
         f"""\
         import coverage as __coverage
@@ -94,7 +94,7 @@ class CoverageNotebookClient(NotebookClient):
 
         async with self.async_setup_kernel(**kwargs):
             assert self.kc is not None
-            self.log.info("Executing notebook with kernel: %s" % self.kernel_name)
+            self.log.info(f"Executing notebook with kernel: {self.kernel_name}")
             msg_id = await ensure_async(self.kc.kernel_info())
             info_msg = await self.async_wait_for_reply(msg_id)
             if info_msg is not None:
@@ -177,8 +177,7 @@ class CoverageError(Exception):
     def from_exec_reply(cls, phase, reply):
         """Instantiate from an execution reply."""
         return cls(
-            f"An error occurred while executing coverage {phase}:\n"
-            f"{reply['content']}"
+            f"An error occurred while executing coverage {phase}:\n{reply['content']}"
         )
 
     @classmethod
@@ -188,7 +187,7 @@ class CoverageError(Exception):
         return cls(
             f"An error occurred while executing coverage {phase}:\n"
             f"{traceback}\n"
-            f"{output.get('ename', '<Error>')}: { output.get('evalue', '')}"
+            f"{output.get('ename', '<Error>')}: {output.get('evalue', '')}"
         )
 
 
@@ -197,7 +196,7 @@ class CoverageError(Exception):
 class ExecuteResult:
     """Result of notebook execution."""
 
-    exec_error: Union[None, Exception] = attr.ib(
+    exec_error: None | Exception = attr.ib(
         validator=instance_of((type(None), Exception)),
         metadata={"help": "Execution exception."},
     )
@@ -236,13 +235,13 @@ class ExecuteResult:
 def execute_notebook(
     notebook: NotebookNode,
     *,
-    resources: Union[dict, None] = None,
-    cwd: Union[str, None] = None,
+    resources: dict | None = None,
+    cwd: str | None = None,
     timeout: int = 120,
     allow_errors: bool = False,
     with_coverage: bool = False,
-    cov_config_file: Union[str, None] = None,
-    cov_source: Union[List[str], None] = None,
+    cov_config_file: str | None = None,
+    cov_source: list[str] | None = None,
 ) -> ExecuteResult:
     """Execute a notebook.
 

--- a/pytest_notebook/execution.py
+++ b/pytest_notebook/execution.py
@@ -4,6 +4,7 @@ from contextlib import nullcontext
 import copy
 import json
 import logging
+import os
 from pathlib import Path
 import tempfile
 from textwrap import dedent
@@ -24,6 +25,10 @@ logger = logging.getLogger(__name__)
 HELP_COVERAGE = "Record coverage data, with coverage.py."
 HELP_COVERAGE_CONFIG = "Determines what coverage configuration file to read."
 HELP_COVERAGE_SOURCE = "A list of file paths or package names to measure coverage for."
+HELP_EXEC_ENV = (
+    "Environment variables to set for the kernel, "
+    "in addition to the inherited environment."
+)
 
 COVERAGE_KEY = "coverage_data"
 
@@ -239,6 +244,7 @@ def execute_notebook(
     cwd: str | None = None,
     timeout: int = 120,
     allow_errors: bool = False,
+    exec_env: dict | None = None,
     with_coverage: bool = False,
     cov_config_file: str | None = None,
     cov_source: list[str] | None = None,
@@ -250,6 +256,8 @@ def execute_notebook(
     :param timeout: The maximum time to wait (in seconds) for execution of each cell.
     :param allow_errors: If False, execution is stopped after the first unexpected
         exception (cells tagged ``raises-exception`` are expected)
+    :param exec_env: Environment variables to set for the kernel,
+        in addition to the inherited environment.
     :param with_coverage: Record code coverage with coverage.py
     :param cov_config_file: Determines what coverage configuration file to read.
     :param cov_source: A list of file paths or package names to measure coverage for.
@@ -274,8 +282,16 @@ def execute_notebook(
             cov_config_file=cov_config_file,
             cov_source=cov_source,
         )
+        kernel_kwargs = {}
+        if exec_env is not None:
+            # merge with the current environment,
+            # since a supplied `env` replaces it entirely
+            kernel_kwargs["env"] = {
+                **os.environ,
+                **{key: str(value) for key, value in exec_env.items()},
+            }
         try:
-            client.execute()
+            client.execute(**kernel_kwargs)
         except (CellExecutionError, CellTimeoutError, CoverageError) as err:
             exec_error = err
 

--- a/pytest_notebook/ipy_magic.py
+++ b/pytest_notebook/ipy_magic.py
@@ -4,6 +4,7 @@ Load via: ``%load_ext pytest_notebook.ipy_magic``,
 then ``%pytest`` and ``%%pytest`` can be accessed.
 
 """
+
 # TODO post solution to stackoverflow:
 # https://stackoverflow.com/questions/41304311/running-pytest-test-functions-inside-a-jupyter-notebook
 import os
@@ -12,16 +13,13 @@ import shlex
 import subprocess
 import sys
 import tempfile
-from typing import List, Tuple, Union
 
 EXEC_NAME = "pytest"
 CONFIG_FILE_NAME = "pytest.ini"
 MAIN_FILE_NAME = "test_ipycell.py"
 
 
-def parse_cell_content(
-    cell: Union[str, None]
-) -> Tuple[List[str], List[str], List[str]]:
+def parse_cell_content(cell: str | None) -> tuple[list[str], list[str], list[str]]:
     """Parse the cell contents.
 
     :returns: (test_content, config_content, literals_content)
@@ -64,9 +62,7 @@ def parse_cell_content(
     return test_content, config_content, literals_content
 
 
-def eval_literals(
-    literals: List[str], local_ns: Union[dict, None]
-) -> List[Tuple[str, str]]:
+def eval_literals(literals: list[str], local_ns: dict | None) -> list[tuple[str, str]]:
     """Evaluate and yield literal items."""
     for literal in literals:
         literal = literal.strip()
@@ -100,7 +96,7 @@ def eval_literals(
         yield evaluated
 
 
-def write_file(content: List[str], file_name: str, temp_dir: Union[str, Path]):
+def write_file(content: list[str], file_name: str, temp_dir: str | Path):
     """Write file to the ``temp_dir``."""
     if content:
         if isinstance(temp_dir, str):
@@ -110,7 +106,7 @@ def write_file(content: List[str], file_name: str, temp_dir: Union[str, Path]):
         temp_dir.joinpath(file_name).write_text("\n".join(content))
 
 
-def run_pytest(args: List[str], cwd: Union[str, Path, None] = None):
+def run_pytest(args: list[str], cwd: str | Path | None = None):
     """Run pytest, with live output.
 
     Adapted from https://stackoverflow.com/a/18422264/5033292
@@ -131,9 +127,7 @@ def run_pytest(args: List[str], cwd: Union[str, Path, None] = None):
         sys.stdout.write(c.decode(sys.stdout.encoding or "utf8", "ignore"))
 
 
-def pytest(
-    line: str = "", cell: Union[str, None] = None, local_ns: Union[dict, None] = None
-):
+def pytest(line: str = "", cell: str | None = None, local_ns: dict | None = None):
     """Run pytest.
 
     ``%pytest arg1 arg2 ...`` will run pytest in a temporary directory.

--- a/pytest_notebook/nb_regression.py
+++ b/pytest_notebook/nb_regression.py
@@ -23,6 +23,7 @@ from pytest_notebook.execution import (
     HELP_COVERAGE,
     HELP_COVERAGE_CONFIG,
     HELP_COVERAGE_SOURCE,
+    HELP_EXEC_ENV,
     execute_notebook,
 )
 from pytest_notebook.notebook import (
@@ -152,6 +153,18 @@ class NBRegressionFixture:
             raise TypeError("exec_timeout must be an integer")
         if value <= 0:
             raise ValueError("exec_timeout must be larger than 0")
+
+    exec_env: dict | None = attr.ib(None, metadata={"help": HELP_EXEC_ENV})
+
+    @exec_env.validator
+    def _validate_exec_env(self, attribute, value):
+        if value is None:
+            return
+        if not isinstance(value, dict):
+            raise TypeError("exec_env must be None or a dict")
+        for key in value:
+            if not isinstance(key, str):
+                raise TypeError(f"exec_env key '{key}' must be a string")
 
     coverage: bool = attr.ib(False, metadata={"help": HELP_COVERAGE})
 
@@ -288,6 +301,7 @@ class NBRegressionFixture:
                 cwd=self.exec_cwd,
                 timeout=self.exec_timeout,
                 allow_errors=self.exec_allow_errors,
+                exec_env=self.exec_env,
                 with_coverage=self.coverage,
                 cov_config_file=self.cov_config,
                 cov_source=self.cov_source,

--- a/pytest_notebook/nb_regression.py
+++ b/pytest_notebook/nb_regression.py
@@ -1,9 +1,10 @@
 """Jupyter Notebook Regression Test Class."""
+
 import copy
 import logging
 import os
 import sys
-from typing import Any, List, TextIO, Tuple, Union
+from typing import Any, TextIO
 
 import attr
 from attr.validators import instance_of
@@ -87,10 +88,10 @@ class NBRegressionResult:
         metadata={"help": "Notebook after execution and post-processing."},
     )
 
-    diff_full: List[DiffEntry] = attr.ib(
+    diff_full: list[DiffEntry] = attr.ib(
         metadata={"help": "Full diff of initial/final notebooks."}
     )
-    diff_filtered: List[DiffEntry] = attr.ib(
+    diff_filtered: list[DiffEntry] = attr.ib(
         metadata={
             "help": (
                 "Diff of initial/final notebooks, "
@@ -125,7 +126,7 @@ class NBRegressionFixture:
     exec_notebook: bool = attr.ib(
         True, instance_of(bool), metadata={"help": HELP_EXEC_NOTEBOOK}
     )
-    exec_cwd: Union[str, None] = attr.ib(
+    exec_cwd: str | None = attr.ib(
         None, instance_of((type(None), str)), metadata={"help": HELP_EXEC_CWD}
     )
 
@@ -164,14 +165,14 @@ class NBRegressionFixture:
             except ImportError:
                 raise ImportError("The 'coverage' package must be installed.")
 
-    cov_config: Union[str, None] = attr.ib(
+    cov_config: str | None = attr.ib(
         None, instance_of((type(None), str)), metadata={"help": HELP_COVERAGE_CONFIG}
     )
-    cov_source: Union[str, Tuple[str]] = attr.ib(
+    cov_source: str | tuple[str] = attr.ib(
         None, instance_of((type(None), tuple)), metadata={"help": HELP_COVERAGE_SOURCE}
     )
 
-    cov_merge: Union[CoverageType, None] = attr.ib(
+    cov_merge: CoverageType | None = attr.ib(
         None, metadata={"help": HELP_COVERAGE_MERGE}, hash=True
     )
 
@@ -251,7 +252,7 @@ class NBRegressionFixture:
         super().__setattr__(key, value)
 
     def check(
-        self, path: Union[TextIO, str], raise_errors: bool = True
+        self, path: TextIO | str, raise_errors: bool = True
     ) -> NBRegressionResult:
         """Execute the Notebook and compare its initial vs. final contents.
 

--- a/pytest_notebook/notebook.py
+++ b/pytest_notebook/notebook.py
@@ -1,16 +1,12 @@
 """Module for working with notebook."""
+
+from collections.abc import Callable, Mapping
 import copy
 from functools import lru_cache
-
-try:
-    # Python <= 3.8
-    from importlib_resources import files
-except ImportError:
-    from importlib.resources import files
-
+from importlib.resources import files
 import json
 import re
-from typing import Any, Callable, Mapping, TextIO, Tuple, Union
+from typing import Any, TextIO
 
 import attr
 from attr.validators import instance_of
@@ -28,7 +24,7 @@ META_KEY = "nbreg"
 
 
 def mapping_to_dict(
-    obj: Any, strip_keys: list = (), leaf_func: Union[Callable, None] = None
+    obj: Any, strip_keys: list = (), leaf_func: Callable | None = None
 ) -> dict:
     """Recursively convert mappable objects to dicts, including in lists and tuples.
 
@@ -52,7 +48,7 @@ def mapping_to_dict(
 
 
 def gather_json_paths(
-    obj: Any, paths: list, types: Union[Tuple, None] = None, curr_path: tuple = ()
+    obj: Any, paths: list, types: tuple | None = None, curr_path: tuple = ()
 ) -> Any:
     """Recursively gather paths to non dict/list elements of a json-like object.
 
@@ -93,7 +89,7 @@ def gather_json_paths(
 
 
 def regex_replace_nb(
-    notebook: NotebookNode, replacements: Tuple[Tuple[str, str, str]]
+    notebook: NotebookNode, replacements: tuple[tuple[str, str, str]]
 ) -> NotebookNode:
     """Return a new notebook with string regex replacements applied.
 
@@ -257,16 +253,14 @@ def config_from_metadata(nb: NotebookNode) -> dict:
     )
 
 
-def load_notebook(
-    path: Union[TextIO, str], as_version=DEFAULT_NB_VERSION
-) -> NotebookNode:
+def load_notebook(path: TextIO | str, as_version=DEFAULT_NB_VERSION) -> NotebookNode:
     """Load the notebook from file."""
     return nbformat.read(path, as_version=as_version)
 
 
 def load_notebook_with_config(
-    path: Union[TextIO, str], as_version=DEFAULT_NB_VERSION
-) -> Tuple[NotebookNode, MetadataConfig]:
+    path: TextIO | str, as_version=DEFAULT_NB_VERSION
+) -> tuple[NotebookNode, MetadataConfig]:
     """Load the notebook from file, and scan its metadata for config data."""
     notebook = nbformat.read(path, as_version=as_version)
     nb_config = config_from_metadata(notebook)

--- a/pytest_notebook/plugin.py
+++ b/pytest_notebook/plugin.py
@@ -10,7 +10,9 @@ For more information on writing pytest plugins see:
 - https://docs.pytest.org/en/latest/_modules/_pytest/hookspec.html
 
 """
-import os
+
+import fnmatch
+from pathlib import Path
 import shlex
 
 import pytest
@@ -244,7 +246,7 @@ def gather_config_options(pytestconfig):
 def pytest_report_header(config):
     """Add header information for pytest execution."""
 
-    kwargs, other_args = gather_config_options(config)
+    kwargs, _ = gather_config_options(config)
     header = []
     if kwargs.get("exec_notebook", True) and kwargs.get("exec_cwd", None):
         header.append(f"NB exec dir: {kwargs['exec_cwd']}")
@@ -259,20 +261,29 @@ def pytest_report_header(config):
 def nb_regression(pytestconfig):
     """Fixture to execute a Jupyter Notebook, and test its output is as expected."""
 
-    kwargs, other_args = gather_config_options(pytestconfig)
+    kwargs, _ = gather_config_options(pytestconfig)
     return NBRegressionFixture(**kwargs)
 
 
-def pytest_collect_file(path, parent):
+def _matches_pattern(file_path: Path, pattern: str) -> bool:
+    """Match a file against an fnmatch pattern.
+
+    Patterns containing a path separator are matched against the full path,
+    otherwise against the file name (mirroring ``py.path.local.fnmatch``).
+    """
+    if "/" in pattern:
+        return fnmatch.fnmatch(file_path.as_posix(), pattern)
+    return fnmatch.fnmatch(file_path.name, pattern)
+
+
+def pytest_collect_file(file_path: Path, parent):
     """Collect Jupyter notebooks using the specified pytest hook."""
-    kwargs, other_args = gather_config_options(parent.config)
+    _, other_args = gather_config_options(parent.config)
     if other_args.get("nb_test_files", False) and any(
-        path.fnmatch(pat) for pat in other_args.get("nb_file_fnmatch", ["*.ipynb"])
+        _matches_pattern(file_path, pat)
+        for pat in other_args.get("nb_file_fnmatch", ["*.ipynb"])
     ):
-        try:
-            return JupyterNbCollector.from_parent(parent, fspath=path)
-        except AttributeError:
-            return JupyterNbCollector(path, parent)
+        return JupyterNbCollector.from_parent(parent, path=file_path)
 
 
 class JupyterNbCollector(pytest.File):
@@ -283,11 +294,7 @@ class JupyterNbCollector(pytest.File):
 
     def collect(self):
         """Collect tests for the notebook."""
-        name = os.path.splitext(os.path.basename(self.fspath))[0]
-        try:
-            yield JupyterNbTest.from_parent(self, name=f"nbregression({name})")
-        except AttributeError:
-            yield JupyterNbTest(f"nbregression({name})", self)
+        yield JupyterNbTest.from_parent(self, name=f"nbregression({self.path.stem})")
 
 
 class JupyterNbTest(pytest.Item):
@@ -299,15 +306,15 @@ class JupyterNbTest(pytest.Item):
         self._fixtureinfo = self.session._fixturemanager.getfixtureinfo(
             self.parent, NBRegressionFixture.check, NBRegressionFixture
         )  # this is required for --setup-plan
-        notebook, nb_config = load_notebook_with_config(self.fspath)
+        _, nb_config = load_notebook_with_config(str(self.path))
         if nb_config.skip:
             self.add_marker(pytest.mark.skip(reason=nb_config.skip_reason))
 
     def runtest(self):
         """Run the test."""
-        kwargs, other_args = gather_config_options(self.config)
+        kwargs, _ = gather_config_options(self.config)
         fixture = NBRegressionFixture(**kwargs)
-        fixture.check(self.fspath)
+        fixture.check(str(self.path))
 
     def repr_failure(self, exc_info):
         """Handle exception raised by ``self.runtest()``.
@@ -320,4 +327,4 @@ class JupyterNbTest(pytest.Item):
 
     def reportinfo(self):
         """Report location of item."""
-        return self.fspath, 0, f"notebook: {self.name}"
+        return self.path, 0, f"notebook: {self.name}"

--- a/pytest_notebook/plugin.py
+++ b/pytest_notebook/plugin.py
@@ -15,8 +15,10 @@ import fnmatch
 from pathlib import Path
 import shlex
 
+from nbclient.exceptions import CellExecutionError
 import pytest
 
+from pytest_notebook.execution import HELP_EXEC_ENV
 from pytest_notebook.nb_regression import (
     HELP_COVERAGE,
     HELP_DIFF_COLOR_WORDS,
@@ -105,6 +107,7 @@ def pytest_addoption(parser):
         default=NotSet(),
     )
     parser.addini("nb_exec_timeout", help=HELP_EXEC_TIMEOUT, default=NotSet())
+    parser.addini("nb_exec_env", type="linelist", help=HELP_EXEC_ENV, default=NotSet())
     parser.addini("nb_coverage", type="bool", help=HELP_COVERAGE, default=NotSet())
     parser.addini(
         "nb_post_processors", type="linelist", help=HELP_POST_PROCS, default=NotSet()
@@ -191,6 +194,31 @@ def validate_diff_replace(pytestconfig):
     return tuple(output)
 
 
+def validate_exec_env(pytestconfig):
+    """Extract the ``nb_exec_env`` option from the ini file.
+
+    This should be a list of lines of the format ``KEY=VALUE``::
+
+        nb_exec_env =
+            MY_VAR=my_value
+            PYTHONPATH=src
+
+    """
+    nb_exec_env = pytestconfig.getini("nb_exec_env")
+    if isinstance(nb_exec_env, NotSet):
+        return None
+
+    env = {}
+    for line in nb_exec_env:
+        key, sep, value = line.partition("=")
+        if not sep or not key.strip():
+            raise ValueError(
+                f"nb_exec_env line is not of the format KEY=VALUE: '{line}'"
+            )
+        env[key.strip()] = value
+    return env
+
+
 def gather_config_options(pytestconfig):
     """Gather all options, from command-line and ini file.
 
@@ -224,6 +252,10 @@ def gather_config_options(pytestconfig):
     nb_diff_replace = validate_diff_replace(pytestconfig)
     if nb_diff_replace is not None:
         nbreg_kwargs["diff_replace"] = nb_diff_replace
+
+    nb_exec_env = validate_exec_env(pytestconfig)
+    if nb_exec_env is not None:
+        nbreg_kwargs["exec_env"] = nb_exec_env
 
     # options from pytest_cov
     # see: https://github.com/pytest-dev/pytest-cov/blob/master/src/pytest_cov/plugin.py
@@ -314,7 +346,14 @@ class JupyterNbTest(pytest.Item):
         """Run the test."""
         kwargs, _ = gather_config_options(self.config)
         fixture = NBRegressionFixture(**kwargs)
-        fixture.check(str(self.path))
+        try:
+            fixture.check(str(self.path))
+        except CellExecutionError as err:
+            # allow a notebook to skip itself at runtime,
+            # by raising ``pytest.skip(...)`` within a cell
+            if err.ename == "Skipped":
+                pytest.skip(err.evalue)
+            raise
 
     def repr_failure(self, exc_info):
         """Handle exception raised by ``self.runtest()``.

--- a/pytest_notebook/post_processors.py
+++ b/pytest_notebook/post_processors.py
@@ -7,6 +7,7 @@ and output a (new notebook, resources).
 import copy
 import functools
 from importlib.metadata import entry_points
+import inspect
 import logging
 import re
 import textwrap
@@ -38,9 +39,11 @@ def load_processor(name: str):
 
 def document_processors():
     """Create formatted string of all preprocessor docstrings."""
+    # cleandoc normalises docstring indentation across python versions
+    # (python 3.13+ strips common leading whitespace at compile time)
     return "\n\n".join(
         [
-            f"{n}:\n{textwrap.indent(load_processor(n).__doc__, '  ').rstrip()}"
+            f"{n}:\n{textwrap.indent(inspect.cleandoc(load_processor(n).__doc__), '  ')}"
             for n in sorted(list_processor_names())
         ]
     )

--- a/pytest_notebook/post_processors.py
+++ b/pytest_notebook/post_processors.py
@@ -3,20 +3,15 @@
 All functions should take (notebook, resources) as input,
 and output a (new notebook, resources).
 """
+
 import copy
 import functools
+from importlib.metadata import entry_points
 import logging
 import re
 import textwrap
-from typing import Tuple
 
 from nbformat import NotebookNode
-
-try:
-    # python <= 3.9
-    from importlib_metadata import entry_points
-except ImportError:
-    from importlib.metadata import entry_points
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +76,7 @@ RGX_BACKSPACE = re.compile(r"[^\n]\b")
 @cell_preprocessor
 def coalesce_streams(
     cell: NotebookNode, resources: dict, index: int
-) -> Tuple[NotebookNode, dict]:
+) -> tuple[NotebookNode, dict]:
     """Merge all stream outputs with shared names into single streams.
 
     This ensure deterministic outputs.
@@ -135,7 +130,7 @@ def coalesce_streams(
 @cell_preprocessor
 def blacken_code(
     cell: NotebookNode, resources: dict, index: int
-) -> Tuple[NotebookNode, dict]:
+) -> tuple[NotebookNode, dict]:
     """Format python source code with black (see https://black.readthedocs.io)."""
     try:
         import black
@@ -161,7 +156,7 @@ def blacken_code(
 @cell_preprocessor
 def beautifulsoup(
     cell: NotebookNode, resources: dict, index: int
-) -> Tuple[NotebookNode, dict]:
+) -> tuple[NotebookNode, dict]:
     """Format text/html and image/svg+xml outputs with beautiful-soup.
 
     See: https://beautiful-soup-4.readthedocs.io.

--- a/pytest_notebook/utils.py
+++ b/pytest_notebook/utils.py
@@ -1,4 +1,5 @@
 """Utility functions."""
+
 import os
 import textwrap
 import warnings

--- a/tests/raw_files/different_outputs.ipynb
+++ b/tests/raw_files/different_outputs.ipynb
@@ -408,11 +408,11 @@
      "evalue": "there was an error",
      "output_type": "error",
      "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[15], line 5\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mthere was an error\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mrange\u001b[39m(\u001b[38;5;241m10\u001b[39m):\n\u001b[0;32m----> 5\u001b[0m     \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mi\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[15], line 3\u001b[0m, in \u001b[0;36mfunc\u001b[0;34m(b)\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mfunc\u001b[39m(b):\n\u001b[0;32m----> 3\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mthere was an error\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
-      "\u001b[0;31mValueError\u001b[0m: there was an error"
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[15]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      1\u001b[39m print(\u001b[33m'before exception'\u001b[39m)\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m func(b):\n\u001b[32m      3\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m ValueError(\u001b[33m'there was an error'\u001b[39m)\n\u001b[32m      4\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;28;01min\u001b[39;00m range(\u001b[32m10\u001b[39m):\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m     func(i)\n",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[15]\u001b[39m\u001b[32m, line 3\u001b[39m, in \u001b[36mfunc\u001b[39m\u001b[34m(b)\u001b[39m\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m func(b):\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m ValueError(\u001b[33m'there was an error'\u001b[39m)\n",
+      "\u001b[31mValueError\u001b[39m: there was an error"
      ]
     }
    ],
@@ -450,7 +450,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "version": "3.11.15"
   },
   "toc": {
    "base_numbering": 1,

--- a/tests/test_nb_diff/test_diff_to_string.txt
+++ b/tests/test_nb_diff/test_diff_to_string.txt
@@ -183,24 +183,28 @@
 +    [0;32m----> 3[0;31m     [0;32mraise[0m [0mValueError[0m[0;34m([0m[0;34m'there was an error'[0m[0;34m)[0m[0;34m[0m[0;34m[0m[0m
 +    [0m[1;32m      4[0m [0;32mfor[0m [0mi[0m [0;32min[0m [0mrange[0m[0;34m([0m[0;36m10[0m[0;34m)[0m[0;34m:[0m[0;34m[0m[0;34m[0m[0m
 +    [1;32m      5[0m     [0mfunc[0m[0;34m([0m[0mi[0m[0;34m)[0m[0;34m[0m[0;34m[0m[0m
++  item[4]: [0;31mValueError[0m: there was an error
 
-## deleted /cells/16/outputs/1/traceback/0-3:
--  item[0]: [0;31m---------------------------------------------------------------------------[0m
--  item[1]: [0;31mValueError[0m                                Traceback (most recent call last)
+## deleted /cells/16/outputs/1/traceback/0-4:
+-  item[0]: [31m---------------------------------------------------------------------------[39m
+-  item[1]: [31mValueError[39m                                Traceback (most recent call last)
 -  item[2]:
--    Cell [0;32mIn[15], line 5[0m
--    [1;32m      3[0m     [38;5;28;01mraise[39;00m [38;5;167;01mValueError[39;00m([38;5;124m'[39m[38;5;124mthere was an error[39m[38;5;124m'[39m)
--    [1;32m      4[0m [38;5;28;01mfor[39;00m i [38;5;129;01min[39;00m [38;5;28mrange[39m([38;5;241m10[39m):
--    [0;32m----> 5[0m     [43mfunc[49m[43m([49m[43mi[49m[43m)[49m
+-    [36mCell[39m[36m [39m[32mIn[15][39m[32m, line 5[39m
+-    [32m      1[39m print([33m'before exception'[39m)
+-    [32m      2[39m [38;5;28;01mdef[39;00m func(b):
+-    [32m      3[39m     [38;5;28;01mraise[39;00m ValueError([33m'there was an error'[39m)
+-    [32m      4[39m [38;5;28;01mfor[39;00m i [38;5;28;01min[39;00m range([32m10[39m):
+-    [32m----> [39m[32m5[39m     func(i)
 -  item[3]:
--    Cell [0;32mIn[15], line 3[0m, in [0;36mfunc[0;34m(b)[0m
--    [1;32m      2[0m [38;5;28;01mdef[39;00m [38;5;21mfunc[39m(b):
--    [0;32m----> 3[0m     [38;5;28;01mraise[39;00m [38;5;167;01mValueError[39;00m([38;5;124m'[39m[38;5;124mthere was an error[39m[38;5;124m'[39m)
+-    [36mCell[39m[36m [39m[32mIn[15][39m[32m, line 3[39m, in [36mfunc[39m[34m(b)[39m
+-    [32m      2[39m [38;5;28;01mdef[39;00m func(b):
+-    [32m----> [39m[32m3[39m     [38;5;28;01mraise[39;00m ValueError([33m'there was an error'[39m)
+-  item[4]: [31mValueError[39m: there was an error
 
 ## deleted /metadata/celltoolbar:
 -  Tags
 
 ## modified /metadata/language_info/version:
--  3.8.18
+-  3.11.15
 +  3.6.7
 

--- a/tests/test_nb_diff/test_notebooks_unequal.yml
+++ b/tests/test_nb_diff/test_notebooks_unequal.yml
@@ -350,8 +350,9 @@
               [0m\e[0;34m:\e[0m\e[0;34m\e[0m\e[0;34m\e[0m\e[0m\n\e[1;32m      5\e\
               [0m     \e[0mfunc\e[0m\e[0;34m(\e[0m\e[0mi\e[0m\e[0;34m)\e[0m\e[0;34m\e\
               [0m\e[0;34m\e[0m\e[0m\n"
+            - "\e[0;31mValueError\e[0m: there was an error"
           - key: 0
-            length: 4
+            length: 5
             op: removerange
           key: traceback
           op: patch

--- a/tests/test_nb_regression.py
+++ b/tests/test_nb_regression.py
@@ -1,4 +1,5 @@
 """Tests for ``NBRegressionFixture``."""
+
 import os
 
 import pytest

--- a/tests/test_nb_regression.py
+++ b/tests/test_nb_regression.py
@@ -2,6 +2,7 @@
 
 import os
 
+import nbformat
 import pytest
 
 from pytest_notebook.execution import COVERAGE_KEY
@@ -14,6 +15,31 @@ def test_init_fixture():
     """Test initialisation of NBRegressionFixture."""
     fixture = NBRegressionFixture(exec_timeout=10)
     assert fixture.exec_timeout == 10
+
+
+def test_regression_exec_env(tmp_path):
+    """Test that ``exec_env`` variables are set for the kernel."""
+    cell = nbformat.v4.new_code_cell(
+        "import os\nprint(os.environ['PYTEST_NB_EXEC_ENV_VAR'])", execution_count=1
+    )
+    cell.outputs = [nbformat.v4.new_output("stream", name="stdout", text="hallo\n")]
+    notebook = nbformat.v4.new_notebook(
+        cells=[cell],
+        metadata={
+            "kernelspec": {
+                "name": "python3",
+                "display_name": "Python 3",
+                "language": "python",
+            }
+        },
+    )
+    path = tmp_path / "test_env.ipynb"
+    nbformat.write(notebook, str(path))
+    fixture = NBRegressionFixture(
+        exec_env={"PYTEST_NB_EXEC_ENV_VAR": "hallo"},
+        diff_ignore=("/metadata/language_info", "/cells/*/execution_count"),
+    )
+    fixture.check(str(path))
 
 
 def test_regression_fail():

--- a/tests/test_nb_regression.py
+++ b/tests/test_nb_regression.py
@@ -86,6 +86,9 @@ def test_regression_regex_replace_pass():
             r"\<ipython\-input\-[\-0-9a-zA-Z]*\>",
             "<ipython-input-XXX>",
         ),
+        # traceback formatting (colours, shown context lines) varies
+        # between IPython versions, so finally normalise each line entirely
+        ("/cells/*/outputs/*/traceback", r"(?s)\A.*\Z", "<TRACEBACK-LINE>"),
     )
     fixture.check(os.path.join(PATH, "raw_files", "different_outputs.ipynb"))
 

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,4 +1,5 @@
 """Tests for pytest_notebook.notebook."""
+
 from pytest_notebook.notebook import (
     META_KEY,
     MetadataConfig,

--- a/tests/test_plugin_collector.py
+++ b/tests/test_plugin_collector.py
@@ -1,4 +1,5 @@
 """Test the  plugin collection and direct invocation of notebooks."""
+
 import os
 
 PATH = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_plugin_collector.py
+++ b/tests/test_plugin_collector.py
@@ -2,7 +2,13 @@
 
 import os
 
+import nbformat
+
 PATH = os.path.dirname(os.path.realpath(__file__))
+
+KERNELSPEC = {
+    "kernelspec": {"name": "python3", "display_name": "Python 3", "language": "python"}
+}
 
 
 def copy_nb_to_tempdir(in_name="different_outputs.ipynb", out_name="test_nb.ipynb"):
@@ -61,4 +67,46 @@ def test_run_pass_with_meta(testdir):
     result.stdout.fnmatch_lines(["*::nbregression(test_nb) PASSED*"])
 
     # make sure that that we get a non '0' exit code for the testsuite
+    assert result.ret == 0
+
+
+def test_run_skip_inside_notebook(testdir):
+    """Test that a notebook can skip itself, by raising ``pytest.skip`` in a cell."""
+    notebook = nbformat.v4.new_notebook(
+        cells=[
+            nbformat.v4.new_code_cell(
+                "import pytest\npytest.skip('skipping from within the notebook')"
+            )
+        ],
+        metadata=KERNELSPEC,
+    )
+    nbformat.write(notebook, "test_nb.ipynb")
+    result = testdir.runpytest("--nb-test-files", "-v", "-rs")
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(["*skipping from within the notebook*", "*1 skipped*"])
+    assert result.ret == 0
+
+
+def test_run_with_exec_env_ini(testdir):
+    """Test ``nb_exec_env`` and ``nb_diff_ignore`` set in the ini file."""
+    cell = nbformat.v4.new_code_cell(
+        "import os\nprint(os.environ['PYTEST_NB_EXEC_ENV_VAR'])", execution_count=1
+    )
+    cell.outputs = [nbformat.v4.new_output("stream", name="stdout", text="hallo\n")]
+    notebook = nbformat.v4.new_notebook(cells=[cell], metadata=KERNELSPEC)
+    nbformat.write(notebook, "test_nb.ipynb")
+    testdir.makeini(
+        """
+        [pytest]
+        nb_test_files = True
+        nb_exec_env =
+            PYTEST_NB_EXEC_ENV_VAR=hallo
+        nb_diff_ignore =
+            /metadata/language_info
+            /cells/*/execution_count
+        """
+    )
+    result = testdir.runpytest("-v")
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(["*::nbregression(test_nb) PASSED*"])
     assert result.ret == 0

--- a/tests/test_plugin_fixture.py
+++ b/tests/test_plugin_fixture.py
@@ -1,4 +1,5 @@
 """Test the  ``nb_regression`` plugin fixture."""
+
 import os
 
 import attr

--- a/tests/test_postprocessors/test_beautifulsoup.py
+++ b/tests/test_postprocessors/test_beautifulsoup.py
@@ -1,4 +1,5 @@
 """Tests for beautifulsoup post-processor."""
+
 from pytest_notebook.notebook import create_notebook, mapping_to_dict, prepare_cell
 from pytest_notebook.post_processors import beautifulsoup
 

--- a/tests/test_postprocessors/test_blacken_code.py
+++ b/tests/test_postprocessors/test_blacken_code.py
@@ -1,4 +1,5 @@
 """Tests for blacken_code post-processor."""
+
 import textwrap
 
 from pytest_notebook.notebook import create_notebook, mapping_to_dict, prepare_cell

--- a/tests/test_postprocessors/test_plugins/test_documentation.txt
+++ b/tests/test_postprocessors/test_plugins/test_documentation.txt
@@ -1,7 +1,7 @@
 beautifulsoup:
   Format text/html and image/svg+xml outputs with beautiful-soup.
 
-      See: https://beautiful-soup-4.readthedocs.io.
+  See: https://beautiful-soup-4.readthedocs.io.
 
 blacken_code:
   Format python source code with black (see https://black.readthedocs.io).
@@ -9,7 +9,7 @@ blacken_code:
 coalesce_streams:
   Merge all stream outputs with shared names into single streams.
 
-      This ensure deterministic outputs.
+  This ensure deterministic outputs.
 
-      Adapted from:
-      https://github.com/computationalmodelling/nbval/blob/master/nbval/plugin.py.
+  Adapted from:
+  https://github.com/computationalmodelling/nbval/blob/master/nbval/plugin.py.

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,24 @@
-# To use tox, see https://tox.readthedocs.io
+# To use tox, see https://tox.wiki
 # Simply pip or conda install tox
-# If you use conda, you may also want to install tox-conda
-# then run `tox` or `tox -e py37 -- {pytest args}`
+# then run `tox` or `tox -e py311 -- {pytest args}`
 
 # To ensure rebuild of the tox environment,
-# either simple delete the .tox folder or use `tox -r`
+# either simply delete the .tox folder or use `tox -r`
 
 [tox]
-envlist = py38
+envlist = py311
 
 [testenv]
 usedevelop = true
 
-[testenv:py{38,39,310,311}]
-extras = testing
+[testenv:py{310,311,312,313}]
+dependency_groups = test
 commands = pytest {posargs}
 
 [testenv:docs-{clean,update}]
 extras = docs
 changedir = docs
-whitelist_externals = make
+allowlist_externals = make
 setenv =
     PYDEVD_DISABLE_FILE_VALIDATION = 1
 commands =


### PR DESCRIPTION
Modernization of the package and repository setup, following the conventions of [markdown-it-py](https://github.com/executablebooks/markdown-it-py). Prepares a **v0.11.0** release.

## ‼️ Breaking changes

- **Python 3.10+** is now required (3.8/3.9 dropped, 3.13 officially supported); `importlib-metadata`/`importlib-resources` backports removed
- **pytest 7.4+** is now required: the notebook collector is ported from the `py.path`/`fspath` API (removed in pytest 8) to the `pathlib`-based collection API — the plugin now works on pytest 8/9, fixes #73, #81
- The `testing` and `code_style` extras are replaced by PEP 735 dependency groups `test` and `pre_commit` (`pip install --group test -e .`); the `docs` extra is retained for Read the Docs

## ⬆️ Dependency upgrades

- Un-pin `attrs` (`<23,>=19` → `>=21`), `nbclient` (`~=0.5.10` → `>=0.5.10`) and `coverage` (`~=5.0` → `>=6.5`), fixes #84
- One code fix required: coverage ≥6.4 rejects `config_file=None`, now passes `False` (the old meaning of `None`)
- Test suite verified green against the current latest resolution: pytest 9.1.1, nbclient 0.11, attrs 26, coverage 7.15, IPython 9, black 26
- Traceback regression fixtures regenerated for modern IPython formatting

## ✨ New features

- Notebooks can skip themselves at runtime by raising `pytest.skip(...)` within a cell, fixes #43
- New `exec_env` fixture option / `nb_exec_env` ini option (lines of `KEY=VALUE`) to set environment variables for the kernel (e.g. `PYTHONPATH` for importing a local package), fixes #15, fixes #85
- A new test confirms `nb_diff_ignore` is applied from the ini file (#5)

## 🔧 Repo infrastructure

- Add `AGENTS.md` (commit conventions, dev workflow, architecture overview)
- CI: Python 3.10–3.13 matrix, `setup-python@v5` with pip caching, `codecov-action@v5`, explicit `permissions` + `concurrency` cancellation
- Publish job switched to **PyPI trusted publishing** (OIDC) — ⚠️ requires registering the publisher for the `pypi` environment on pypi.org before the next tag; the `PYPI_KEY` secret can then be deleted
- Dependabot: monthly → weekly
- pre-commit: `ruff` v0.1.6 → v0.15 (`.ipynb` files excluded from ruff, since fixtures contain deliberately unformatted code); ruff config migrated to `[tool.ruff.lint]`
- Read the Docs: ubuntu-24.04 / Python 3.12; contributing docs updated (flake8/black → ruff, extras → groups)

## Tests

`pytest --cov=pytest_notebook --nb-coverage`: **75 passed, 1 skipped** locally on Python 3.11 with all dependencies at latest; `pre-commit run --all-files` passes.

