### PR TITLE
✨ nbdime config ignores, plus fixes for latent bugs found by audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Editors like VS Code also have automatic code reformat utilities, which can adhe
 
 ## License
 
-Distributed under the terms of the [BSD-3](http://opensource.org/licenses/BSD-3-Clause) license,
+Distributed under the terms of the [BSD-3](https://opensource.org/licenses/BSD-3-Clause) license,
 `pytest-notebook` is free and open source software.
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![RTD][rtd-badge]][rtd-link]
 [![PyPI][pypi-badge]][pypi-link]
 [![Conda][conda-badge]][conda-link]
-[![Code style: black][black-badge]][black-link]
 
 A [pytest](https://github.com/pytest-dev/pytest) plugin for regression testing and regenerating [Jupyter Notebooks](https://jupyter.org/).
 
@@ -40,7 +39,7 @@ regenerate the notebooks, saving the new outputs.
     3. The notebook and cell level metadata.
 
 - Post-processor plugin entry-points, allow for customisable modifications of the notebook,
-  including source code formatting with [black](https://github.com/ambv/black)
+  including source code formatting with [black](https://github.com/psf/black)
 
 ![Configuration Examples](docs/source/_static/collaged_in_out.png)
 
@@ -70,7 +69,7 @@ pip install -e .
 
 ## Usage
 
-See the documentation at: http://pytest-notebook.readthedocs.io/
+See the documentation at: https://pytest-notebook.readthedocs.io/
 
 If you want to test some sample notebooks, add the `--nb-test-files` flag:
 
@@ -137,10 +136,8 @@ If you encounter any problems, please [file an issue](https://github.com/chrisjs
 [cov-badge]:https://codecov.io/gh/chrisjsewell/pytest-notebook/branch/master/graph/badge.svg
 [cov-link]: https://codecov.io/gh/chrisjsewell/pytest-notebook
 [rtd-badge]: https://readthedocs.org/projects/pytest-notebook/badge
-[rtd-link]: http://pytest-notebook.readthedocs.io/
+[rtd-link]: https://pytest-notebook.readthedocs.io/
 [pypi-badge]: https://img.shields.io/pypi/v/pytest-notebook.svg
 [pypi-link]: https://pypi.org/project/pytest-notebook
 [conda-badge]: https://anaconda.org/conda-forge/pytest-notebook/badges/version.svg
 [conda-link]: https://anaconda.org/conda-forge/pytest-notebook
-[black-badge]: https://img.shields.io/badge/code%20style-black-000000.svg
-[black-link]: https://github.com/ambv/black

--- a/docs/source/apidoc/pytest_notebook.rst
+++ b/docs/source/apidoc/pytest_notebook.rst
@@ -30,6 +30,6 @@ Module contents
 
 .. automodule:: pytest_notebook
    :members:
-   :undoc-members:
-   :show-inheritance:
    :private-members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -9,6 +9,7 @@
 * ⬆️ Un-pin `attrs` (now `>=21`), `nbclient` (now `>=0.5.10`, tested against 0.11) and `coverage` (now v6.5+, tested against v7) ([#84](https://github.com/chrisjsewell/pytest-notebook/issues/84))
 * ✨ Notebooks can now skip themselves at runtime, by raising `pytest.skip(...)` within a cell ([#43](https://github.com/chrisjsewell/pytest-notebook/issues/43))
 * ✨ Add `exec_env` fixture option / `nb_exec_env` ini option (lines of `KEY=VALUE`), to set environment variables for the kernel, e.g. `PYTHONPATH` ([#15](https://github.com/chrisjsewell/pytest-notebook/issues/15), [#85](https://github.com/chrisjsewell/pytest-notebook/issues/85))
+* ✨ Add `nb_diff_use_nbdime_config` ini option, to load diff-ignore paths from an [nbdime configuration file](https://nbdime.readthedocs.io/en/latest/config.html#configuring-ignores) (`nbdime_config.json`) ([#38](https://github.com/chrisjsewell/pytest-notebook/issues/38))
 * 🔧 Move development dependencies from `testing`/`code_style` extras to PEP 735 dependency groups (`test`, `pre_commit`); the `docs` extra is retained
 * 🔧 Add `AGENTS.md`, update pre-commit hooks (ruff v0.15) and CI (Python 3.10-3.13 matrix, PyPI trusted publishing, weekly dependabot)
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,6 +6,12 @@
 
 * ‼️ Drop Python 3.8/3.9 support; add official Python 3.13 support
 * 🐛 Fix compatibility with pytest 8/9: port the notebook collector from the removed `py.path`/`fspath` API to the `pathlib` based API ([#73](https://github.com/chrisjsewell/pytest-notebook/issues/73), [#81](https://github.com/chrisjsewell/pytest-notebook/issues/81))
+* 🐛 Fix merging notebook coverage into pytest-cov's data with coverage v7 (the `aliases` argument was renamed `map_path`); coverage v7+ is now required for coverage features
+* 🐛 Fix an `UnboundLocalError` when `nb_exec_notebook = False` and pytest-cov is active
+* 🐛 Fix removed trailing cells/outputs being diffed at incorrect indices
+* 🐛 Fix `nb_diff_ignore`/`nb_diff_replace` paths also matching longer cell indices with the same prefix (e.g. `/cells/1` also matching `/cells/11`)
+* 🐛 Fix backspace characters not being cancelled out by the `coalesce_streams` post-processor
+* 🐛 Fix `NBRegressionFixture.check` permanently setting `exec_cwd` on first use
 * ⬆️ Un-pin `attrs` (now `>=21`), `nbclient` (now `>=0.5.10`, tested against 0.11) and `coverage` (now v6.5+, tested against v7) ([#84](https://github.com/chrisjsewell/pytest-notebook/issues/84))
 * ✨ Notebooks can now skip themselves at runtime, by raising `pytest.skip(...)` within a cell ([#43](https://github.com/chrisjsewell/pytest-notebook/issues/43))
 * ✨ Add `exec_env` fixture option / `nb_exec_env` ini option (lines of `KEY=VALUE`), to set environment variables for the kernel, e.g. `PYTHONPATH` ([#15](https://github.com/chrisjsewell/pytest-notebook/issues/15), [#85](https://github.com/chrisjsewell/pytest-notebook/issues/85))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ intersphinx_mapping = {
     "nbdime": ("https://nbdime.readthedocs.io/en/latest/", None),
     "nbformat": ("https://nbformat.readthedocs.io/en/latest/", None),
     "attr": ("https://www.attrs.org/en/stable/", None),
-    "coverage": ("https://coverage.readthedocs.io/en/6.2/", None),
+    "coverage": ("https://coverage.readthedocs.io/en/latest/", None),
 }
 
 intersphinx_aliases = {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -114,4 +114,4 @@ Indices and tables
 .. _pytest_cov: https://pytest-cov.readthedocs.io
 .. _Jupyter: https://jupyter.org/
 .. _nbdime: https://nbdime.readthedocs.io
-.. _black: https://github.com/ambv/black
+.. _black: https://github.com/psf/black

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -85,7 +85,7 @@ License
 -------
 
 Distributed under the terms of the
-`BSD-3 <http://opensource.org/licenses/BSD-3-Clause>`__ license,
+`BSD-3 <https://opensource.org/licenses/BSD-3-Clause>`__ license,
 ``pytest-notebook`` is free and open source software.
 
 Issues

--- a/docs/source/user_guide/get_started.md
+++ b/docs/source/user_guide/get_started.md
@@ -63,8 +63,8 @@ can check and adhere to this standard.
 The documentation can be created locally by:
 
 ```shell
->> tox -e py37-docs-clean
->> tox -e py37-docs-update
+>> tox -e docs-clean
+>> tox -e docs-update
 ```
 
 [ci-badge]: https://github.com/chrisjsewell/pytest-notebook/workflows/continuous-integration/badge.svg?branch=master
@@ -72,7 +72,7 @@ The documentation can be created locally by:
 [cov-badge]:https://codecov.io/gh/chrisjsewell/pytest-notebook/branch/master/graph/badge.svg
 [cov-link]: https://codecov.io/gh/chrisjsewell/pytest-notebook
 [rtd-badge]: https://readthedocs.org/projects/pytest-notebook/badge
-[rtd-link]: http://pytest-notebook.readthedocs.io/
+[rtd-link]: https://pytest-notebook.readthedocs.io/
 [pypi-badge]: https://img.shields.io/pypi/v/pytest-notebook.svg
 [pypi-link]: https://pypi.org/project/pytest-notebook
 [conda-badge]: https://anaconda.org/conda-forge/pytest-notebook/badges/version.svg

--- a/docs/source/user_guide/tutorial_config.md
+++ b/docs/source/user_guide/tutorial_config.md
@@ -238,7 +238,7 @@ notebook4.cells[0].metadata["tags"] = ["raises-exception"]
 
 +++
 
-To add the [pytest skip decorator](http://doc.pytest.org/en/latest/skipping.html#skipping-test-functions) to a notebook, you can add `skip=True` to the notebook metadata.
+To add the [pytest skip decorator](https://doc.pytest.org/en/latest/skipping.html#skipping-test-functions) to a notebook, you can add `skip=True` to the notebook metadata.
 
 ```{code-cell} ipython3
 notebook5 = nbformat.v4.new_notebook()
@@ -253,6 +253,76 @@ notebook5
 (nbformat.writes(notebook5), "test_notebook5.ipynb")
 ***
 ```
+
+A notebook can also skip itself at runtime, by raising `pytest.skip` within a cell,
+for example if a required service or API key is not available:
+
+```{code-cell} ipython3
+notebook_skip = nbformat.v4.new_notebook(
+    cells=[
+        nbformat.v4.new_code_cell(
+            "import pytest\npytest.skip('skipping from within the notebook')"
+        )
+    ]
+)
+
+notebook_skip
+```
+
+```{code-cell} ipython3
+%%pytest -v --color=yes -rs --nb-test-files
+
+***
+(nbformat.writes(notebook_skip), "test_notebook_skip.ipynb")
+***
+```
+
+## Setting Environment Variables for the Kernel
+
++++
+
+The `nb_exec_env` option sets environment variables for the kernel executing the notebook,
+in addition to the inherited environment.
+Each line is of the format `KEY=VALUE`.
+This can be used, for example, to add a local package to the `PYTHONPATH`, or to pass credentials:
+
+```ini
+[pytest]
+nb_exec_env =
+    PYTHONPATH=src
+    MY_API_KEY=xxx
+```
+
+The equivalent option for {py:class}`~pytest_notebook.nb_regression.NBRegressionFixture` is `exec_env`, as a dict.
+
+## Using an nbdime Configuration File
+
++++
+
+If you already configure [nbdime ignores](https://nbdime.readthedocs.io/en/latest/config.html#configuring-ignores)
+with an `nbdime_config.json` file, setting `nb_diff_use_nbdime_config` will also
+load diff-ignore paths from the `Ignore` mappings in its `Global`, `Diff` and `NbDiff` sections
+(merged with any `nb_diff_ignore` setting):
+
+```ini
+[pytest]
+nb_diff_use_nbdime_config = True
+```
+
+```json
+{
+  "Diff": {
+    "Ignore": {
+      "/cells/*/execution_count": true,
+      "/cells/*/metadata": ["collapsed", "autoscroll"],
+      "/metadata": ["language_info"]
+    }
+  }
+}
+```
+
+The file is looked up in the current working directory, then the pytest root directory
+(other locations searched by nbdime itself, such as the Jupyter configuration directories, are not used).
 
 (post_processors)=
 
@@ -289,7 +359,7 @@ for the internally provided plugins.
 +++
 
 An example of this is the `blacken_code` post-processor,
-which applies the [black](https://github.com/ambv/black) formatter
+which applies the [black](https://github.com/psf/black) formatter
 to all source code cells.
 
 This is particularly useful for re-generating notebooks.

--- a/docs/source/user_guide/tutorial_config.md
+++ b/docs/source/user_guide/tutorial_config.md
@@ -301,8 +301,9 @@ The equivalent option for {py:class}`~pytest_notebook.nb_regression.NBRegression
 
 If you already configure [nbdime ignores](https://nbdime.readthedocs.io/en/latest/config.html#configuring-ignores)
 with an `nbdime_config.json` file, setting `nb_diff_use_nbdime_config` will also
-load diff-ignore paths from the `Ignore` mappings in its `Global`, `Diff` and `NbDiff` sections
-(merged with any `nb_diff_ignore` setting):
+load diff-ignore paths from the `Ignore` mappings in its `Diff`, `GitDiff` and `NbDiff` sections
+(with later sections taking precedence per path, mirroring the `nbdiff` command).
+These are merged with the `nb_diff_ignore` setting, or the default `diff_ignore`:
 
 ```ini
 [pytest]
@@ -321,8 +322,13 @@ nb_diff_use_nbdime_config = True
 }
 ```
 
-The file is looked up in the current working directory, then the pytest root directory
+Only the first file found is used, looked up in the current working directory,
+then the pytest root directory
 (other locations searched by nbdime itself, such as the Jupyter configuration directories, are not used).
+
+There is no equivalent {py:class}`~pytest_notebook.nb_regression.NBRegressionFixture` option;
+instead call {py:func}`pytest_notebook.diffing.load_nbdime_ignore_config`
+and pass the result to `diff_ignore`.
 
 (post_processors)=
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ test = [
   "pytest-cov",
   "pytest-regressions",
   "ipykernel",
-  "coverage>=6.5",
+  "coverage>=7",
   "black",
   "beautifulsoup4~=4.12",
 ]

--- a/pytest_notebook/diffing.py
+++ b/pytest_notebook/diffing.py
@@ -2,7 +2,9 @@
 
 from collections.abc import Sequence
 import copy
+import json
 import operator
+from pathlib import Path
 import re
 
 from nbdime.diff_format import DiffEntry, SequenceDiffBuilder
@@ -155,6 +157,77 @@ def filter_diff(
                 new_diff = None
         return new_diff
     return diff
+
+
+NBDIME_CONFIG_SECTIONS = ("Global", "Diff", "NbDiff")
+
+
+def load_nbdime_ignore_config(path: str | Path) -> tuple[str, ...]:
+    """Extract diff-ignore paths from an nbdime configuration file.
+
+    The file should be in the `nbdime configuration format
+    <https://nbdime.readthedocs.io/en/latest/config.html#configuring-ignores>`__,
+    e.g.::
+
+        {
+          "Diff": {
+            "Ignore": {
+              "/cells/*/execution_count": true,
+              "/cells/*/metadata": ["collapsed", "autoscroll"],
+              "/metadata": ["language_info"]
+            }
+          }
+        }
+
+    ``Ignore`` mappings are read from the ``Global``, ``Diff`` and ``NbDiff``
+    sections (with later sections taking precedence, per path).
+    A value of ``True`` ignores the whole path, ``False`` de-selects the path,
+    and a list of strings ignores ``<path>/<key>`` for each key.
+
+    :returns: a tuple of diff-ignore paths, suitable for ``filter_diff``
+        or ``NBRegressionFixture.diff_ignore``.
+    """
+    with open(path, encoding="utf8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise TypeError(f"nbdime config is not a mapping: {path}")
+
+    ignores = {}
+    for section_name in NBDIME_CONFIG_SECTIONS:
+        section = data.get(section_name, None)
+        if section is None:
+            continue
+        if not isinstance(section, dict):
+            raise TypeError(f"'{section_name}' is not a mapping, in: {path}")
+        ignore = section.get("Ignore", {})
+        if not isinstance(ignore, dict):
+            raise TypeError(f"'{section_name}/Ignore' is not a mapping, in: {path}")
+        for key, value in ignore.items():
+            if not key.startswith("/"):
+                raise ValueError(
+                    f"'{section_name}/Ignore' path '{key}' "
+                    f"does not start with '/', in: {path}"
+                )
+            if not (
+                value in (True, False)
+                or (
+                    isinstance(value, list)
+                    and all(isinstance(item, str) for item in value)
+                )
+            ):
+                raise ValueError(
+                    f"'{section_name}/Ignore/{key}' value is not "
+                    f"true, false or a list of strings, in: {path}"
+                )
+        ignores.update(ignore)
+
+    paths = set()
+    for key, value in ignores.items():
+        if value is True:
+            paths.add(key)
+        elif isinstance(value, list):
+            paths.update(f"{key}/{sub_key}" for sub_key in value)
+    return tuple(sorted(paths))
 
 
 def diff_to_string(

--- a/pytest_notebook/diffing.py
+++ b/pytest_notebook/diffing.py
@@ -58,7 +58,7 @@ def diff_sequence_simple(
             di.patch(i, cd)
 
     if len(initial) > len(final):
-        di.removerange(len(initial), len(initial) - len(final))
+        di.removerange(len(final), len(initial) - len(final))
     if len(initial) < len(final):
         di.addrange(len(initial), final[len(initial) :])
 
@@ -140,7 +140,9 @@ def filter_diff(
         for i in reversed(range(len(path_elements))):
             # iteratively star more elements from the right side
             new_path = join_path(path_elements[:i] + star_path(path_elements[i:]))
-            if any(new_path.startswith(p) for p in remove_paths):
+            # match only on full path-segment boundaries,
+            # so that e.g. '/cells/1' does not also match '/cells/11'
+            if any(new_path == p or new_path.startswith(p + "/") for p in remove_paths):
                 return None
 
         new_diff = copy.deepcopy(diff)
@@ -159,7 +161,9 @@ def filter_diff(
     return diff
 
 
-NBDIME_CONFIG_SECTIONS = ("Global", "Diff", "NbDiff")
+# the sections read for the `nbdiff` entrypoint, in increasing precedence
+# (mirroring the class hierarchy merging of ``nbdime.config.build_config``)
+NBDIME_CONFIG_SECTIONS = ("Diff", "GitDiff", "NbDiff")
 
 
 def load_nbdime_ignore_config(path: str | Path) -> tuple[str, ...]:
@@ -179,9 +183,11 @@ def load_nbdime_ignore_config(path: str | Path) -> tuple[str, ...]:
           }
         }
 
-    ``Ignore`` mappings are read from the ``Global``, ``Diff`` and ``NbDiff``
-    sections (with later sections taking precedence, per path).
+    ``Ignore`` mappings are read from the ``Diff``, ``GitDiff`` and ``NbDiff``
+    sections (with later sections taking precedence, per path),
+    mirroring what nbdime itself reads for the ``nbdiff`` command.
     A value of ``True`` ignores the whole path, ``False`` de-selects the path,
+    ``null`` removes the path (as if it was never set),
     and a list of strings ignores ``<path>/<key>`` for each key.
 
     :returns: a tuple of diff-ignore paths, suitable for ``filter_diff``
@@ -208,18 +214,23 @@ def load_nbdime_ignore_config(path: str | Path) -> tuple[str, ...]:
                     f"'{section_name}/Ignore' path '{key}' "
                     f"does not start with '/', in: {path}"
                 )
-            if not (
-                value in (True, False)
+            if value is None:
+                # a null value removes the path, as per nbdime
+                ignores.pop(key, None)
+            elif (
+                value is True
+                or value is False
                 or (
                     isinstance(value, list)
                     and all(isinstance(item, str) for item in value)
                 )
             ):
+                ignores[key] = value
+            else:
                 raise ValueError(
                     f"'{section_name}/Ignore/{key}' value is not "
-                    f"true, false or a list of strings, in: {path}"
+                    f"true, false, null or a list of strings, in: {path}"
                 )
-        ignores.update(ignore)
 
     paths = set()
     for key, value in ignores.items():

--- a/pytest_notebook/nb_regression.py
+++ b/pytest_notebook/nb_regression.py
@@ -71,6 +71,8 @@ HELP_POST_PROCS = (
 )
 HELP_COVERAGE_MERGE = "A coverage.Coverage instance, to merge coverage results with."
 
+DEFAULT_DIFF_IGNORE = ("/cells/*/outputs/*/traceback",)
+
 
 class NBRegressionError(Exception):
     """Exception to signal a regression test fail."""
@@ -231,7 +233,7 @@ class NBRegressionFixture:
 
     diff_ignore: tuple = attr.ib(
         # TODO replace this default with a diff_replace one?
-        ("/cells/*/outputs/*/traceback",),
+        DEFAULT_DIFF_IGNORE,
         metadata={"help": HELP_DIFF_IGNORE},
     )
 
@@ -290,15 +292,14 @@ class NBRegressionFixture:
         nb_initial, nb_config = load_notebook_with_config(path)
 
         resources = copy.deepcopy(self.process_resources)
-        if not self.exec_cwd:
-            self.exec_cwd = os.path.dirname(abspath)
+        exec_cwd = self.exec_cwd or os.path.dirname(abspath)
 
         if self.exec_notebook:
             logger.debug("Executing notebook.")
             exec_results = execute_notebook(
                 nb_initial,
                 resources=resources,
-                cwd=self.exec_cwd,
+                cwd=exec_cwd,
                 timeout=self.exec_timeout,
                 allow_errors=self.exec_allow_errors,
                 exec_env=self.exec_env,
@@ -314,11 +315,13 @@ class NBRegressionFixture:
             nb_final = nb_initial
 
         # TODO merge on fail option (using pytest-cov --no-cov-on-fail)
-        if self.cov_merge and exec_results.has_coverage:
+        if self.exec_notebook and self.cov_merge and exec_results.has_coverage:
             logger.info("Merging coverage.")
+            aliases = _get_coverage_aliases(self.cov_merge)
             self.cov_merge.get_data().update(
                 exec_results.coverage_data(debug=self.cov_merge._debug),
-                aliases=_get_coverage_aliases(self.cov_merge),
+                # note aliases was renamed map_path in coverage v7
+                map_path=aliases.map if aliases else None,
             )
             # we also take this opportunity to remove ''
             # from the unmatched source packages, which is caused by using `--cov=`

--- a/pytest_notebook/notebook.py
+++ b/pytest_notebook/notebook.py
@@ -106,7 +106,11 @@ def regex_replace_nb(
             for i in reversed(range(len(nb_path)))
         }
         for path_str, regex, replace in replacements:
-            if not any(p.startswith(path_str) for p in compare_paths):
+            # match only on full path-segment boundaries,
+            # so that e.g. '/cells/1' does not also match '/cells/11'
+            if not any(
+                p == path_str or p.startswith(path_str + "/") for p in compare_paths
+            ):
                 continue
 
             nb_element = new_notebook

--- a/pytest_notebook/plugin.py
+++ b/pytest_notebook/plugin.py
@@ -21,6 +21,7 @@ import pytest
 from pytest_notebook.diffing import load_nbdime_ignore_config
 from pytest_notebook.execution import HELP_EXEC_ENV
 from pytest_notebook.nb_regression import (
+    DEFAULT_DIFF_IGNORE,
     HELP_COVERAGE,
     HELP_DIFF_COLOR_WORDS,
     HELP_DIFF_IGNORE,
@@ -231,19 +232,36 @@ def validate_exec_env(pytestconfig):
     return env
 
 
+NBDIME_IGNORE_STASH_KEY = pytest.StashKey()
+
+
 def gather_nbdime_ignore_config(pytestconfig):
     """Load diff-ignore paths from an ``nbdime_config.json`` file.
 
-    The file is looked up in the current working directory,
-    then the pytest root directory.
+    The (first) file is looked up in the current working directory,
+    then the pytest root directory, and the result is cached for the session.
     """
-    for directory in (Path.cwd(), pytestconfig.rootpath):
+    if NBDIME_IGNORE_STASH_KEY in pytestconfig.stash:
+        return pytestconfig.stash[NBDIME_IGNORE_STASH_KEY]
+
+    directories = [Path.cwd()]
+    if pytestconfig.rootpath != directories[0]:
+        directories.append(pytestconfig.rootpath)
+    for directory in directories:
         config_file = directory / "nbdime_config.json"
         if config_file.is_file():
-            return load_nbdime_ignore_config(config_file)
-    raise FileNotFoundError(
-        "nb_diff_use_nbdime_config is set, but no nbdime_config.json found in: "
-        f"{Path.cwd()} or {pytestconfig.rootpath}"
+            try:
+                ignores = load_nbdime_ignore_config(config_file)
+            except Exception as exc:
+                raise pytest.UsageError(
+                    f"Invalid nbdime configuration file '{config_file}': {exc}"
+                ) from exc
+            pytestconfig.stash[NBDIME_IGNORE_STASH_KEY] = ignores
+            return ignores
+    locations = " or ".join(str(directory) for directory in directories)
+    raise pytest.UsageError(
+        f"nb_diff_use_nbdime_config is set, but no nbdime_config.json found in: "
+        f"{locations}"
     )
 
 
@@ -289,7 +307,7 @@ def gather_config_options(pytestconfig):
     if not isinstance(use_nbdime_config, NotSet) and str2bool(use_nbdime_config):
         nbreg_kwargs["diff_ignore"] = tuple(
             sorted(
-                set(nbreg_kwargs.get("diff_ignore", ()))
+                set(nbreg_kwargs.get("diff_ignore", DEFAULT_DIFF_IGNORE))
                 | set(gather_nbdime_ignore_config(pytestconfig))
             )
         )
@@ -337,10 +355,13 @@ def nb_regression(pytestconfig):
 def _matches_pattern(file_path: Path, pattern: str) -> bool:
     """Match a file against an fnmatch pattern.
 
-    Patterns containing a path separator are matched against the full path,
+    Patterns containing a path separator are matched against the full path
+    (relative patterns match any trailing path segments),
     otherwise against the file name (mirroring ``py.path.local.fnmatch``).
     """
     if "/" in pattern:
+        if not pattern.startswith("/"):
+            pattern = "*/" + pattern
         return fnmatch.fnmatch(file_path.as_posix(), pattern)
     return fnmatch.fnmatch(file_path.name, pattern)
 

--- a/pytest_notebook/plugin.py
+++ b/pytest_notebook/plugin.py
@@ -18,6 +18,7 @@ import shlex
 from nbclient.exceptions import CellExecutionError
 import pytest
 
+from pytest_notebook.diffing import load_nbdime_ignore_config
 from pytest_notebook.execution import HELP_EXEC_ENV
 from pytest_notebook.nb_regression import (
     HELP_COVERAGE,
@@ -38,6 +39,11 @@ from pytest_notebook.notebook import load_notebook_with_config, validate_regex_r
 HELP_TEST_FILES = "Treat each .ipynb file as a test to be run."
 HELP_FILE_FNMATCH = (
     "The fnmatch pattern(s) for collecting notebooks, default: '*.ipynb'."
+)
+HELP_DIFF_USE_NBDIME_CONFIG = (
+    "Also load diff-ignore paths from an nbdime configuration file "
+    "(nbdime_config.json), looked up in the current working directory, "
+    "then the pytest root directory."
 )
 
 
@@ -114,6 +120,12 @@ def pytest_addoption(parser):
     )
     parser.addini(
         "nb_diff_ignore", type="linelist", help=HELP_DIFF_IGNORE, default=NotSet()
+    )
+    parser.addini(
+        "nb_diff_use_nbdime_config",
+        type="bool",
+        help=HELP_DIFF_USE_NBDIME_CONFIG,
+        default=NotSet(),
     )
     parser.addini(
         "nb_diff_replace", type="linelist", help=HELP_DIFF_REPLACE, default=NotSet()
@@ -219,6 +231,22 @@ def validate_exec_env(pytestconfig):
     return env
 
 
+def gather_nbdime_ignore_config(pytestconfig):
+    """Load diff-ignore paths from an ``nbdime_config.json`` file.
+
+    The file is looked up in the current working directory,
+    then the pytest root directory.
+    """
+    for directory in (Path.cwd(), pytestconfig.rootpath):
+        config_file = directory / "nbdime_config.json"
+        if config_file.is_file():
+            return load_nbdime_ignore_config(config_file)
+    raise FileNotFoundError(
+        "nb_diff_use_nbdime_config is set, but no nbdime_config.json found in: "
+        f"{Path.cwd()} or {pytestconfig.rootpath}"
+    )
+
+
 def gather_config_options(pytestconfig):
     """Gather all options, from command-line and ini file.
 
@@ -256,6 +284,15 @@ def gather_config_options(pytestconfig):
     nb_exec_env = validate_exec_env(pytestconfig)
     if nb_exec_env is not None:
         nbreg_kwargs["exec_env"] = nb_exec_env
+
+    use_nbdime_config = pytestconfig.getini("nb_diff_use_nbdime_config")
+    if not isinstance(use_nbdime_config, NotSet) and str2bool(use_nbdime_config):
+        nbreg_kwargs["diff_ignore"] = tuple(
+            sorted(
+                set(nbreg_kwargs.get("diff_ignore", ()))
+                | set(gather_nbdime_ignore_config(pytestconfig))
+            )
+        )
 
     # options from pytest_cov
     # see: https://github.com/pytest-dev/pytest-cov/blob/master/src/pytest_cov/plugin.py

--- a/pytest_notebook/post_processors.py
+++ b/pytest_notebook/post_processors.py
@@ -73,7 +73,8 @@ def cell_preprocessor(function):
 
 
 RGX_CARRIAGERETURN = re.compile(r".*\r(?=[^\n])")
-RGX_BACKSPACE = re.compile(r"[^\n]\b")
+# note: \x08 is the backspace character (\b would be a regex word boundary)
+RGX_BACKSPACE = re.compile("[^\n]\x08")
 
 
 @cell_preprocessor
@@ -105,11 +106,12 @@ def coalesce_streams(
 
     # process \r and \b characters
     for output in streams.values():
-        old = output.text
-        while len(output.text) < len(old):
-            old = output.text
+        while True:
             # Cancel out anything-but-newline followed by backspace
-            output.text = RGX_BACKSPACE.sub("", output.text)
+            new_text = RGX_BACKSPACE.sub("", output.text)
+            if new_text == output.text:
+                break
+            output.text = new_text
         # Replace all carriage returns not followed by newline
         output.text = RGX_CARRIAGERETURN.sub("", output.text)
 

--- a/tests/test_coalesce_streams.py
+++ b/tests/test_coalesce_streams.py
@@ -17,6 +17,26 @@ def test_coalesce_streams_same():
     assert notebook == new_notebook
 
 
+def test_coalesce_streams_backspace():
+    """Test coalesce_streams cancels out backspace characters."""
+    notebook = create_notebook()
+    notebook.cells.append(
+        prepare_cell(
+            {
+                "cell_type": "code",
+                "execution_count": 1,
+                "metadata": {},
+                "outputs": [
+                    {"name": "stdout", "output_type": "stream", "text": "abc\b\bX\n"}
+                ],
+                "source": "print('abc\\b\\bX')",
+            }
+        )
+    )
+    new_notebook, _ = coalesce_streams(notebook, {})
+    assert new_notebook.cells[0].outputs[0]["text"] == "aX\n"
+
+
 def test_coalesce_streams():
     """Test coalesce_streams if streams require merging."""
     notebook = create_notebook()

--- a/tests/test_filter_diff.py
+++ b/tests/test_filter_diff.py
@@ -22,6 +22,33 @@ def test_filter_diff_cells():
     assert diff == []
 
 
+def test_filter_diff_segment_boundaries():
+    """Test that paths only filter on full segment boundaries.
+
+    e.g. '/cells/1' should not also filter '/cells/11'.
+    """
+    diff = [
+        {
+            "op": "patch",
+            "key": "cells",
+            "diff": [
+                {"op": "patch", "key": 1, "diff": [{"op": "replace", "key": "a"}]},
+                {"op": "patch", "key": 11, "diff": [{"op": "replace", "key": "a"}]},
+            ],
+        }
+    ]
+    filtered = filter_diff(diff, ["/cells/1"])
+    assert filtered == [
+        {
+            "op": "patch",
+            "key": "cells",
+            "diff": [
+                {"op": "patch", "key": 11, "diff": [{"op": "replace", "key": "a"}]}
+            ],
+        }
+    ]
+
+
 def test_filter_diff_outputs():
     diff = filter_diff(get_test_diff(), ["/cells/*/outputs"])
     assert diff == [

--- a/tests/test_nb_diff.py
+++ b/tests/test_nb_diff.py
@@ -1,8 +1,14 @@
+import json
 import os
 
 import nbformat
+import pytest
 
-from pytest_notebook.diffing import diff_notebooks, diff_to_string
+from pytest_notebook.diffing import (
+    diff_notebooks,
+    diff_to_string,
+    load_nbdime_ignore_config,
+)
 from pytest_notebook.notebook import mapping_to_dict
 
 path = os.path.dirname(os.path.realpath(__file__))
@@ -25,6 +31,64 @@ def test_notebooks_unequal(data_regression):
     )
     diff = diff_notebooks(initial, final)
     data_regression.check(mapping_to_dict(diff))
+
+
+def test_load_nbdime_ignore_config(tmp_path):
+    """Test extracting diff-ignore paths from an nbdime configuration file."""
+    config_file = tmp_path / "nbdime_config.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "Global": {
+                    "Ignore": {
+                        "/cells/*/outputs": True,
+                        "/cells/*/execution_count": True,
+                    }
+                },
+                "Diff": {
+                    "Ignore": {
+                        "/cells/*/execution_count": False,
+                        "/cells/*/metadata": ["collapsed", "autoscroll"],
+                        "/metadata": ["language_info"],
+                    }
+                },
+                "NbDiffWeb": {"Ignore": {"/cells/*/source": True}},
+            }
+        )
+    )
+    assert load_nbdime_ignore_config(config_file) == (
+        "/cells/*/metadata/autoscroll",
+        "/cells/*/metadata/collapsed",
+        "/cells/*/outputs",
+        "/metadata/language_info",
+    )
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        [],
+        {"Diff": []},
+        {"Diff": {"Ignore": []}},
+        {"Diff": {"Ignore": {"cells": True}}},
+        {"Diff": {"Ignore": {"/cells": "true"}}},
+        {"Diff": {"Ignore": {"/cells": [1]}}},
+    ],
+    ids=[
+        "not-a-mapping",
+        "section-not-a-mapping",
+        "ignore-not-a-mapping",
+        "path-without-slash",
+        "value-not-bool-or-list",
+        "value-list-not-strings",
+    ],
+)
+def test_load_nbdime_ignore_config_invalid(tmp_path, config):
+    """Test that invalid nbdime configuration files raise errors."""
+    config_file = tmp_path / "nbdime_config.json"
+    config_file.write_text(json.dumps(config))
+    with pytest.raises((TypeError, ValueError)):
+        load_nbdime_ignore_config(config_file)
 
 
 def test_diff_to_string(file_regression):

--- a/tests/test_nb_diff.py
+++ b/tests/test_nb_diff.py
@@ -33,32 +33,62 @@ def test_notebooks_unequal(data_regression):
     data_regression.check(mapping_to_dict(diff))
 
 
+def test_notebooks_unequal_removed_outputs():
+    """Test that removed trailing outputs diff at the correct indices."""
+    cell = nbformat.v4.new_code_cell("print('a')\nprint('b')", execution_count=1)
+    cell.outputs = [
+        nbformat.v4.new_output("stream", name="stdout", text="a\n"),
+        nbformat.v4.new_output("stream", name="stdout", text="b\n"),
+    ]
+    initial = nbformat.v4.new_notebook(cells=[cell])
+    final = nbformat.v4.new_notebook(cells=[nbformat.v4.new_code_cell(cell.source)])
+    diff = diff_notebooks(initial, final)
+    (outputs_diff,) = [
+        entry for entry in diff[0]["diff"][0]["diff"] if entry["key"] == "outputs"
+    ]
+    (removerange,) = outputs_diff["diff"]
+    assert removerange["op"] == "removerange"
+    # the removal starts at the end of the final outputs (0), not the initial
+    assert removerange["key"] == 0
+    assert removerange["length"] == 2
+
+
 def test_load_nbdime_ignore_config(tmp_path):
     """Test extracting diff-ignore paths from an nbdime configuration file."""
     config_file = tmp_path / "nbdime_config.json"
     config_file.write_text(
         json.dumps(
             {
-                "Global": {
+                "Diff": {
                     "Ignore": {
                         "/cells/*/outputs": True,
                         "/cells/*/execution_count": True,
-                    }
-                },
-                "Diff": {
-                    "Ignore": {
-                        "/cells/*/execution_count": False,
-                        "/cells/*/metadata": ["collapsed", "autoscroll"],
+                        "/cells/*/attachments": True,
                         "/metadata": ["language_info"],
                     }
                 },
+                "GitDiff": {
+                    "Ignore": {
+                        # False de-selects a previously ignored path
+                        "/cells/*/execution_count": False,
+                        "/cells/*/metadata": ["collapsed", "autoscroll"],
+                    }
+                },
+                "NbDiff": {
+                    "Ignore": {
+                        # null removes a previously set path
+                        "/cells/*/attachments": None,
+                        "/cells/*/metadata": ["scrolled"],
+                    }
+                },
+                # sections not read by nbdiff are excluded
                 "NbDiffWeb": {"Ignore": {"/cells/*/source": True}},
+                "Global": {"Ignore": {"/nbformat": True}},
             }
         )
     )
     assert load_nbdime_ignore_config(config_file) == (
-        "/cells/*/metadata/autoscroll",
-        "/cells/*/metadata/collapsed",
+        "/cells/*/metadata/scrolled",
         "/cells/*/outputs",
         "/metadata/language_info",
     )
@@ -72,6 +102,7 @@ def test_load_nbdime_ignore_config(tmp_path):
         {"Diff": {"Ignore": []}},
         {"Diff": {"Ignore": {"cells": True}}},
         {"Diff": {"Ignore": {"/cells": "true"}}},
+        {"Diff": {"Ignore": {"/cells": 1}}},
         {"Diff": {"Ignore": {"/cells": [1]}}},
     ],
     ids=[
@@ -79,7 +110,8 @@ def test_load_nbdime_ignore_config(tmp_path):
         "section-not-a-mapping",
         "ignore-not-a-mapping",
         "path-without-slash",
-        "value-not-bool-or-list",
+        "value-str",
+        "value-int",
         "value-list-not-strings",
     ],
 )

--- a/tests/test_nb_regression.py
+++ b/tests/test_nb_regression.py
@@ -61,6 +61,8 @@ def test_regression_diff_ignore_pass():
         "/cells/9/outputs/0/metadata/application/json",
     )
     fixture.check(os.path.join(PATH, "raw_files", "different_outputs.ipynb"))
+    # the fixture should not be mutated by the check
+    assert fixture.exec_cwd is None
 
 
 def test_regression_regex_replace_pass():

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -112,6 +112,23 @@ def test_regex_replace_nb_source():
     }
 
 
+def test_regex_replace_nb_segment_boundaries():
+    """Test that paths only replace on full segment boundaries.
+
+    e.g. '/cells/1' should not also replace in '/cells/11'.
+    """
+    notebook = create_notebook()
+    notebook.cells.extend(
+        [
+            prepare_cell({"metadata": {}, "outputs": [], "source": [f"cell{i}"]})
+            for i in range(12)
+        ]
+    )
+    new_notebook = regex_replace_nb(notebook, [("/cells/1", "cell", "replaced")])
+    assert new_notebook.cells[1].source == "replaced1"
+    assert new_notebook.cells[11].source == "cell11"
+
+
 def test_regex_replace_nb_output():
     """Test regex replacing notebook output."""
     notebook = create_notebook()

--- a/tests/test_plugin_collector.py
+++ b/tests/test_plugin_collector.py
@@ -87,6 +87,63 @@ def test_run_skip_inside_notebook(testdir):
     assert result.ret == 0
 
 
+def test_matches_pattern():
+    """Test fnmatch patterns against the old ``py.path.local.fnmatch`` semantics."""
+    from pathlib import Path
+
+    from pytest_notebook.plugin import _matches_pattern
+
+    file_path = Path("/repo/docs/test_nb.ipynb")
+    assert _matches_pattern(file_path, "*.ipynb")
+    assert _matches_pattern(file_path, "test_nb.ipynb")
+    assert not _matches_pattern(file_path, "other_*.ipynb")
+    # relative patterns with a separator match any trailing path segments
+    assert _matches_pattern(file_path, "docs/*.ipynb")
+    assert _matches_pattern(file_path, "docs/test_nb.ipynb")
+    assert not _matches_pattern(file_path, "other/*.ipynb")
+    # absolute patterns match the full path
+    assert _matches_pattern(file_path, "/repo/docs/*.ipynb")
+    assert not _matches_pattern(file_path, "/other/docs/*.ipynb")
+
+
+def test_run_with_coverage_merge(testdir):
+    """Test that collected notebook coverage is merged into pytest-cov's data."""
+    copy_nb_to_tempdir(os.path.join("coverage_test", "call_package.ipynb"))
+    with open(os.path.join(PATH, "raw_files", "coverage_test", "package.py")) as fh:
+        data = fh.read()
+    with open("package.py", "w") as fh:
+        fh.write(data)
+    testdir.makeini(
+        """
+        [pytest]
+        nb_diff_ignore =
+            /metadata/language_info
+        """
+    )
+    result = testdir.runpytest(
+        "--nb-test-files", "--nb-coverage", "--cov=package", "-v"
+    )
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(["*::nbregression(test_nb) PASSED*", "*package.py*"])
+    assert result.ret == 0
+
+
+def test_run_no_exec_with_cov(testdir):
+    """Test a non-executed run with pytest-cov enabled."""
+    copy_nb_to_tempdir()
+    testdir.makeini(
+        """
+        [pytest]
+        nb_test_files = True
+        nb_exec_notebook = False
+        """
+    )
+    result = testdir.runpytest("--cov", "-v")
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(["*::nbregression(test_nb) PASSED*"])
+    assert result.ret == 0
+
+
 def _write_nb_with_wrong_output(filename="test_nb.ipynb"):
     """Write a notebook whose stored output will differ from its execution."""
     cell = nbformat.v4.new_code_cell("print('hallo')", execution_count=1)
@@ -96,7 +153,7 @@ def _write_nb_with_wrong_output(filename="test_nb.ipynb"):
 
 
 def test_run_with_nbdime_config(testdir):
-    """Test that ignores are loaded from nbdime_config.json, when enabled."""
+    """Test that nbdime_config.json ignores are merged with ``nb_diff_ignore``."""
     import json
 
     _write_nb_with_wrong_output()
@@ -107,7 +164,6 @@ def test_run_with_nbdime_config(testdir):
                     "Ignore": {
                         "/cells/*/outputs": True,
                         "/cells/*/execution_count": True,
-                        "/metadata": ["language_info"],
                     }
                 }
             },
@@ -118,11 +174,53 @@ def test_run_with_nbdime_config(testdir):
         [pytest]
         nb_test_files = True
         nb_diff_use_nbdime_config = True
+        nb_diff_ignore =
+            /metadata/language_info
         """
     )
     result = testdir.runpytest("-v")
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(["*::nbregression(test_nb) PASSED*"])
+    assert result.ret == 0
+
+
+def test_run_with_nbdime_config_missing(testdir):
+    """Test an actionable error, when no nbdime_config.json exists."""
+    _write_nb_with_wrong_output()
+    testdir.makeini(
+        """
+        [pytest]
+        nb_test_files = True
+        nb_diff_use_nbdime_config = True
+        """
+    )
+    result = testdir.runpytest()
+    result.stderr.fnmatch_lines(["*no nbdime_config.json found*"])
+    assert result.ret != 0
+
+
+def test_nbdime_config_preserves_default_ignore(testdir):
+    """Test enabling the nbdime config does not drop the default diff_ignore."""
+    import json
+
+    with open("nbdime_config.json", "w") as handle:
+        json.dump({"Diff": {"Ignore": {"/metadata": ["language_info"]}}}, handle)
+    testdir.makeini(
+        """
+        [pytest]
+        nb_diff_use_nbdime_config = True
+        """
+    )
+    testdir.makepyfile(
+        """
+        def test_opts(nb_regression):
+            assert "/cells/*/outputs/*/traceback" in nb_regression.diff_ignore
+            assert "/metadata/language_info" in nb_regression.diff_ignore
+        """
+    )
+    result = testdir.runpytest("-v")
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(["*::test_opts PASSED*"])
     assert result.ret == 0
 
 

--- a/tests/test_plugin_collector.py
+++ b/tests/test_plugin_collector.py
@@ -87,6 +87,58 @@ def test_run_skip_inside_notebook(testdir):
     assert result.ret == 0
 
 
+def _write_nb_with_wrong_output(filename="test_nb.ipynb"):
+    """Write a notebook whose stored output will differ from its execution."""
+    cell = nbformat.v4.new_code_cell("print('hallo')", execution_count=1)
+    cell.outputs = [nbformat.v4.new_output("stream", name="stdout", text="wrong\n")]
+    notebook = nbformat.v4.new_notebook(cells=[cell], metadata=KERNELSPEC)
+    nbformat.write(notebook, filename)
+
+
+def test_run_with_nbdime_config(testdir):
+    """Test that ignores are loaded from nbdime_config.json, when enabled."""
+    import json
+
+    _write_nb_with_wrong_output()
+    with open("nbdime_config.json", "w") as handle:
+        json.dump(
+            {
+                "Diff": {
+                    "Ignore": {
+                        "/cells/*/outputs": True,
+                        "/cells/*/execution_count": True,
+                        "/metadata": ["language_info"],
+                    }
+                }
+            },
+            handle,
+        )
+    testdir.makeini(
+        """
+        [pytest]
+        nb_test_files = True
+        nb_diff_use_nbdime_config = True
+        """
+    )
+    result = testdir.runpytest("-v")
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(["*::nbregression(test_nb) PASSED*"])
+    assert result.ret == 0
+
+
+def test_run_without_nbdime_config(testdir):
+    """Test that nbdime_config.json is not loaded, when not enabled."""
+    import json
+
+    _write_nb_with_wrong_output()
+    with open("nbdime_config.json", "w") as handle:
+        json.dump({"Diff": {"Ignore": {"/cells/*/outputs": True}}}, handle)
+    result = testdir.runpytest("--nb-test-files", "-v")
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(["*::nbregression(test_nb) FAILED*"])
+    assert result.ret != 0
+
+
 def test_run_with_exec_env_ini(testdir):
     """Test ``nb_exec_env`` and ``nb_diff_ignore`` set in the ini file."""
     cell = nbformat.v4.new_code_cell(


### PR DESCRIPTION
Follow-up to #87, intended to land before the v0.11.0 release.

## ✨ New: load diff-ignores from nbdime configuration files (fixes #38)

New `nb_diff_use_nbdime_config` ini option: when set, diff-ignore paths are also loaded from the `Ignore` mappings of an `nbdime_config.json` file, merged with `nb_diff_ignore` (or the default `diff_ignore`).

- Reads the `Diff`, `GitDiff` and `NbDiff` sections with later sections taking precedence per path — verified empirically against `nbdime.config.build_config("nbdiff")` so semantics match what nbdime itself reads (including `GitDiff`, which nbdime's own docs use as the ignores example)
- `true` ignores a path, `false` de-selects it, `null` removes it, a list of strings ignores `<path>/<key>` per key
- File looked up in the cwd, then the pytest rootdir; parsed once per session; missing/invalid files raise a clean `pytest.UsageError`
- Public helper `pytest_notebook.diffing.load_nbdime_ignore_config()` for direct `NBRegressionFixture` users; documented in the user guide

## 🐛 Latent bugs fixed (found by a codebase audit, each reproduced before fixing)

- **Coverage merge broken with coverage v7**: `CoverageData.update(aliases=)` was renamed `map_path`, so `pytest --cov --nb-coverage` raised `TypeError` at the merge step (coverage v7+ now required; new end-to-end test covers the merge path)
- **`UnboundLocalError`** when `nb_exec_notebook = False` with pytest-cov active
- **Wrong diff indices for removed trailing cells/outputs** (`removerange` offset used the initial length instead of the final), yielding phantom deletions that `diff_ignore` couldn't filter and empty diff output
- **Prefix collisions in ignore/replace paths**: `/cells/1` also matched `/cells/11` in both `filter_diff` and `regex_replace_nb`; now matches only on segment boundaries
- **Backspace handling in `coalesce_streams` never ran** (dead loop) and its regex used `\b` (word boundary) instead of `\x08` (backspace)
- **Collection regression from the pytest-8 port** (#87): relative `nb_file_fnmatch` patterns containing `/` (e.g. `docs/*.ipynb`) never matched; restored the old `py.path` semantics
- **`NBRegressionFixture.check` mutated the fixture**, permanently pinning `exec_cwd` to the first notebook's directory

## 📚 Docs

- Document runtime notebook skipping (`pytest.skip` in a cell) and `nb_exec_env` in the user guide (were only in the changelog)
- Fix broken `tox -e py37-docs-*` commands in get_started.md; remove stale "code style: black" badge; `psf/black` and https URL updates

## Verification

- 94 passed, 1 skipped locally (13 new tests, including regression tests for every bug above); `pre-commit run --all-files` green; docs build succeeds
- The feature was reviewed by two independent adversarial passes; their findings (nbdime section fidelity, default-`diff_ignore` preservation, `UsageError` handling, caching) are incorporated and pinned by tests
