### PR TITLE
🔧 Make example notebooks pass on any Python version

### DIFF
--- a/examples/fail.ipynb
+++ b/examples/fail.ipynb
@@ -30,6 +30,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.12"
+  },
+  "nbreg": {
+   "diff_ignore": [
+    "/metadata/language_info/version"
+   ]
   }
  },
  "nbformat": 4,

--- a/examples/success.ipynb
+++ b/examples/success.ipynb
@@ -30,6 +30,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.12"
+  },
+  "nbreg": {
+   "diff_ignore": [
+    "/metadata/language_info/version"
+   ]
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The example notebooks store `language_info` for Python 3.8.12, so the README's walkthrough (`pytest --nb-test-files *.ipynb` in `examples/`, expecting `success.ipynb` to pass) failed on any other interpreter, with the only diff being `/metadata/language_info/version`.

This adds `nbreg` metadata to both notebooks ignoring that path. Verified with the published v0.11.0 wheel from PyPI on Python 3.11:

- `success.ipynb` → **passes**
- `fail.ipynb` → still **fails**, now solely on its intended output diff (`## modified /cells/0/outputs/0/text`)

This also serves as a live example of per-notebook `nbreg` metadata config, per the README screenshot flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AncEEKRNVmmcM9WKosPhGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AncEEKRNVmmcM9WKosPhGU)_